### PR TITLE
AVX2/SVE benchmarks for vector-to-kernels and user option design change

### DIFF
--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -36,12 +36,26 @@
       "flags": [ "-n", "100" ],
       "extensions": []
     },
-    "gemm_fp32_mlir_vector": {
+    "gemm_fp32_mlir_vector_avx512": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
+      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=8,32 '" ],
       "extensions": []
+    },
+    "gemm_fp32_mlir_vector_avx2": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": {},
+      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=4,16 '" ],
+      "extensions": ["(avx2)"]
+    },
+    "gemm_fp32_mlir_vector_sve": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": {},
+      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=4,32 '" ],
+      "extensions": ["(asimd)"]
     },
     "gemm_bf16_dp2_mlir": {
       "type": "IR-GEN",
@@ -64,12 +78,26 @@
       "flags": [ "-n", "100" ],
       "extensions": []
     },
-    "mlp_fp32_mlir_vector": {
+    "mlp_fp32_mlir_vector_avx512": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
+      "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=8,32 '" ],
       "extensions": []
+    },
+    "mlp_fp32_mlir_vector_avx2": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": {},
+      "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=4,16 '" ],
+      "extensions": ["(avx2)" ]
+    },
+    "mlp_fp32_mlir_vector_sve": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": {},
+      "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=4,32 '" ],
+      "extensions": ["(asimd)"]
     },
     "mlp_bf16_dp2_mlir": {
       "type": "IR-GEN",
@@ -99,7 +127,7 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32 '" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_args_mlir": {
@@ -113,7 +141,7 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32 '" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_3x1024_const_mlir": {
@@ -144,7 +172,7 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args='--def-parallel  --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel  --vector-to-kernels --registerBlocking=8,32 '" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_args_mlir": {
@@ -158,7 +186,7 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args=' --def-parallel  --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
+      "flags": [ "-n", "100", "-run-args=' --def-parallel  --vector-to-kernels --registerBlocking=8,32 '" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_3x1024_const_mlir": {

--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -41,7 +41,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": ["avx512*"]
+      "extensions": ["avx512f"]
     },
     "gemm_fp32_mlir_vector_avx2": {
       "type": "IR-GEN",
@@ -83,7 +83,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": ["avx512*"]
+      "extensions": ["avx512f"]
     },
     "mlp_fp32_mlir_vector_avx2": {
       "type": "IR-GEN",
@@ -128,7 +128,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     },
     "fp32_3x1024_args_mlir": {
       "type": "IR-GEN",
@@ -142,7 +142,7 @@
       "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     },
     "bf16_3x1024_const_mlir": {
       "type": "IR-GEN",
@@ -173,7 +173,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--def-parallel  --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     },
     "fp32_3x1024_args_mlir": {
       "type": "IR-GEN",
@@ -187,7 +187,7 @@
       "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args=' --def-parallel  --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     },
     "bf16_3x1024_const_mlir": {
       "type": "IR-GEN",

--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -41,21 +41,21 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": []
+      "extensions": ["avx512"]
     },
     "gemm_fp32_mlir_vector_avx2": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=4,16 '" ],
-      "extensions": ["(avx2)"]
+      "extensions": ["avx2"]
     },
     "gemm_fp32_mlir_vector_sve": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=4,32 '" ],
-      "extensions": ["(asimd)"]
+      "extensions": ["asimd"]
     },
     "gemm_bf16_dp2_mlir": {
       "type": "IR-GEN",
@@ -83,21 +83,21 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": []
+      "extensions": ["avx512"]
     },
     "mlp_fp32_mlir_vector_avx2": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=4,16 '" ],
-      "extensions": ["(avx2)" ]
+      "extensions": ["avx2" ]
     },
     "mlp_fp32_mlir_vector_sve": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=4,32 '" ],
-      "extensions": ["(asimd)"]
+      "extensions": ["asimd"]
     },
     "mlp_bf16_dp2_mlir": {
       "type": "IR-GEN",
@@ -128,7 +128,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "extensions": [ "avx512" ]
     },
     "fp32_3x1024_args_mlir": {
       "type": "IR-GEN",
@@ -142,7 +142,7 @@
       "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "extensions": [ "avx512" ]
     },
     "bf16_3x1024_const_mlir": {
       "type": "IR-GEN",
@@ -173,7 +173,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--def-parallel  --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "extensions": [ "avx512" ]
     },
     "fp32_3x1024_args_mlir": {
       "type": "IR-GEN",
@@ -187,7 +187,7 @@
       "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args=' --def-parallel  --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "extensions": [ "avx512" ]
     },
     "bf16_3x1024_const_mlir": {
       "type": "IR-GEN",

--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -41,7 +41,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": ["avx512"]
+      "extensions": ["avx512*"]
     },
     "gemm_fp32_mlir_vector_avx2": {
       "type": "IR-GEN",
@@ -83,7 +83,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": ["avx512"]
+      "extensions": ["avx512*"]
     },
     "mlp_fp32_mlir_vector_avx2": {
       "type": "IR-GEN",
@@ -128,7 +128,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     },
     "fp32_3x1024_args_mlir": {
       "type": "IR-GEN",
@@ -142,7 +142,7 @@
       "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     },
     "bf16_3x1024_const_mlir": {
       "type": "IR-GEN",
@@ -173,7 +173,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--def-parallel  --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     },
     "fp32_3x1024_args_mlir": {
       "type": "IR-GEN",
@@ -187,7 +187,7 @@
       "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args=' --def-parallel  --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     },
     "bf16_3x1024_const_mlir": {
       "type": "IR-GEN",

--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -41,7 +41,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": ["avx512f"]
+      "extensions": ["avx512.*"]
     },
     "gemm_fp32_mlir_vector_avx2": {
       "type": "IR-GEN",
@@ -83,7 +83,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": ["avx512f"]
+      "extensions": ["avx512.*"]
     },
     "mlp_fp32_mlir_vector_avx2": {
       "type": "IR-GEN",
@@ -128,7 +128,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_args_mlir": {
       "type": "IR-GEN",
@@ -142,7 +142,7 @@
       "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     },
     "bf16_3x1024_const_mlir": {
       "type": "IR-GEN",
@@ -173,7 +173,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--def-parallel  --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_args_mlir": {
       "type": "IR-GEN",
@@ -187,7 +187,7 @@
       "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args=' --def-parallel  --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     },
     "bf16_3x1024_const_mlir": {
       "type": "IR-GEN",

--- a/benchmarks/config/omp/mlir-fp32-vector-to-kernel.json
+++ b/benchmarks/config/omp/mlir-fp32-vector-to-kernel.json
@@ -6,28 +6,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512" ]
     }
   }},
   {
@@ -37,28 +37,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512" ]
     }
   }},
   {
@@ -68,28 +68,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=1,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512" ]
     }
   }},
   {
@@ -99,28 +99,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=1,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512" ]
     }
   }},
   {
@@ -130,28 +130,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=4,16 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=4,16 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,16 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=4,16 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx2" ]
     }
   }},
   {
@@ -161,28 +161,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=4,16 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=4,16 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,16 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=4,16 '" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx2" ]
     }
   }},
   {
@@ -192,28 +192,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=4,32   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
-      "extensions": [ "(asimd)" ]
+      "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=4,32   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
-      "extensions": [ "(asimd)" ]
+      "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,32   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
-      "extensions": [ "(asimd)" ]
+      "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=4,32   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
-      "extensions": [ "(asimd)" ]
+      "extensions": [ "asimd" ]
     }
   }},
   {
@@ -223,28 +223,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=4,32   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
-      "extensions": [ "(asimd)" ]
+      "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=4,32   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
-      "extensions": [ "(asimd)" ]
+      "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,32   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
-      "extensions": [ "(asimd)" ]
+      "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=4,32   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
-      "extensions": [ "(asimd)" ]
+      "extensions": [ "asimd" ]
     }
   }}
 ]

--- a/benchmarks/config/omp/mlir-fp32-vector-to-kernel.json
+++ b/benchmarks/config/omp/mlir-fp32-vector-to-kernel.json
@@ -1,128 +1,250 @@
-
 [
  {
-  "gemm_fp32_mlir_vector_kernel_32": {
+  "gemm_fp32_mlir_vector_kernel_32_avx512": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32 '" ],
+      "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32 '" ],
+      "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32 '" ],
+      "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32 '" ],
+      "extensions": [ "(avx2)" ]
     }
   }},
   {
-  "mlp_fp32_mlir_vector_kernel_32": {
+  "mlp_fp32_mlir_vector_kernel_32_avx512": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32 '" ],
+      "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32 '" ],
+      "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32 '" ],
+      "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32 '" ],
+      "extensions": [ "(avx2)" ]
     }
   }},
   {
-  "gemm_fp32_mlir_vector_kernel_64": {
+  "gemm_fp32_mlir_vector_kernel_64_avx512": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --lhsTile=16,64 --rhsTile=64,1'" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,64 '" ],
+      "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,4 --vector-to-kernels --lhsTile=16,64 --rhsTile=64,1'" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,4 --vector-to-kernels --registerBlocking=4,64 '" ],
+      "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,4 --vector-to-kernels --lhsTile=16,64 --rhsTile=64,1'" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,4 --vector-to-kernels --registerBlocking=4,64 '" ],
+      "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=1,4 --vector-to-kernels --lhsTile=16,64 --rhsTile=64,1'" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=1,4 --vector-to-kernels --registerBlocking=4,64 '" ],
+      "extensions": [ "(avx2)" ]
     }
   }},
   {
-  "mlp_fp32_mlir_vector_kernel_64": {
+  "mlp_fp32_mlir_vector_kernel_64_avx512": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --lhsTile=16,64 --rhsTile=64,1'" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,64 '" ],
+      "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,4 --vector-to-kernels --lhsTile=16,64 --rhsTile=64,1'" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,4 --vector-to-kernels --registerBlocking=4,64 '" ],
+      "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,4 --vector-to-kernels --lhsTile=16,64 --rhsTile=64,1'" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,4 --vector-to-kernels --registerBlocking=4,64 '" ],
+      "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=1,4 --vector-to-kernels --lhsTile=16,64 --rhsTile=64,1'" ],
-      "extensions": [ "(avx2|asimd)" ]
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=1,4 --vector-to-kernels --registerBlocking=4,64 '" ],
+      "extensions": [ "(avx2)" ]
+    }
+  }},
+  {
+  "gemm_fp32_mlir_vector_kernel_32_avx2": {
+    "fp32_3x1024_omp_2_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=4,32 '" ],
+      "extensions": [ "(avx2)" ]
+    },
+    "fp32_3x1024_omp_4_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=4,32 '" ],
+      "extensions": [ "(avx2)" ]
+    },
+    "fp32_3x1024_omp_8_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,32 '" ],
+      "extensions": [ "(avx2)" ]
+    },
+    "fp32_3x1024_omp_16_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=4,32 '" ],
+      "extensions": [ "(avx2)" ]
+    }
+  }},
+  {
+  "mlp_fp32_mlir_vector_kernel_32_avx2": {
+    "fp32_3x1024_omp_2_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=4,32 '" ],
+      "extensions": [ "(avx2)" ]
+    },
+    "fp32_3x1024_omp_4_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=4,32 '" ],
+      "extensions": [ "(avx2)" ]
+    },
+    "fp32_3x1024_omp_8_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,32 '" ],
+      "extensions": [ "(avx2)" ]
+    },
+    "fp32_3x1024_omp_16_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=4,32 '" ],
+      "extensions": [ "(avx2)" ]
+    }
+  }},
+  {
+  "gemm_fp32_mlir_vector_kernel_32_sve": {
+    "fp32_3x1024_omp_2_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=4,32   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
+      "extensions": [ "(asimd)" ]
+    },
+    "fp32_3x1024_omp_4_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=4,32   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
+      "extensions": [ "(asimd)" ]
+    },
+    "fp32_3x1024_omp_8_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,32   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
+      "extensions": [ "(asimd)" ]
+    },
+    "fp32_3x1024_omp_16_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=4,32   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
+      "extensions": [ "(asimd)" ]
+    }
+  }},
+  {
+  "mlp_fp32_mlir_vector_kernel_32_sve": {
+    "fp32_3x1024_omp_2_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=4,32   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
+      "extensions": [ "(asimd)" ]
+    },
+    "fp32_3x1024_omp_4_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=4,32   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
+      "extensions": [ "(asimd)" ]
+    },
+    "fp32_3x1024_omp_8_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,32   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
+      "extensions": [ "(asimd)" ]
+    },
+    "fp32_3x1024_omp_16_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=4,32   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
+      "extensions": [ "(asimd)" ]
     }
   }}
 ]
-

--- a/benchmarks/config/omp/mlir-fp32-vector-to-kernel.json
+++ b/benchmarks/config/omp/mlir-fp32-vector-to-kernel.json
@@ -6,28 +6,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     }
   }},
   {
@@ -37,28 +37,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     }
   }},
   {
@@ -68,28 +68,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=1,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     }
   }},
   {
@@ -99,28 +99,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=1,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512f" ]
+      "extensions": [ "avx512.*" ]
     }
   }},
   {

--- a/benchmarks/config/omp/mlir-fp32-vector-to-kernel.json
+++ b/benchmarks/config/omp/mlir-fp32-vector-to-kernel.json
@@ -6,28 +6,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     }
   }},
   {
@@ -37,28 +37,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     }
   }},
   {
@@ -68,28 +68,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=1,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     }
   }},
   {
@@ -99,28 +99,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=1,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512" ]
+      "extensions": [ "avx512*" ]
     }
   }},
   {

--- a/benchmarks/config/omp/mlir-fp32-vector-to-kernel.json
+++ b/benchmarks/config/omp/mlir-fp32-vector-to-kernel.json
@@ -6,28 +6,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     }
   }},
   {
@@ -37,28 +37,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     }
   }},
   {
@@ -68,28 +68,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=1,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     }
   }},
   {
@@ -99,28 +99,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=1,4 --vector-to-kernels --registerBlocking=4,64 '" ],
-      "extensions": [ "avx512*" ]
+      "extensions": [ "avx512f" ]
     }
   }},
   {

--- a/benchmarks/config/omp/mlir-fp32-vector-to-kernel.json
+++ b/benchmarks/config/omp/mlir-fp32-vector-to-kernel.json
@@ -129,28 +129,28 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=4,32 '" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=4,16 '" ],
       "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=4,32 '" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=4,16 '" ],
       "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,32 '" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,16 '" ],
       "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=4,32 '" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=4,16 '" ],
       "extensions": [ "(avx2)" ]
     }
   }},
@@ -160,28 +160,28 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=4,32 '" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=4,16 '" ],
       "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=4,32 '" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=4,16 '" ],
       "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,32 '" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,16 '" ],
       "extensions": [ "(avx2)" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=4,32 '" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=4,16 '" ],
       "extensions": [ "(avx2)" ]
     }
   }},

--- a/benchmarks/config/omp/torch-dynamo-vector-to-kernel.json
+++ b/benchmarks/config/omp/torch-dynamo-vector-to-kernel.json
@@ -5,28 +5,28 @@
       "type": "MLIR",
       "benchmark": "pytorch/torch-dynamo-gemm-fp32-3x1024.mlir",
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16  --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16  --vector-to-kernels --registerBlocking=8,32 '" ],
       "extensions": [ ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "MLIR",
       "benchmark": "pytorch/torch-dynamo-gemm-fp32-3x1024.mlir",
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8  --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8  --vector-to-kernels --registerBlocking=8,32 '" ],
       "extensions": [ ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "MLIR",
       "benchmark": "pytorch/torch-dynamo-gemm-fp32-3x1024.mlir",
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8  --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8  --vector-to-kernels --registerBlocking=8,32 '" ],
       "extensions": [ ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "MLIR",
       "benchmark": "pytorch/torch-dynamo-gemm-fp32-3x1024.mlir",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8  --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8  --vector-to-kernels --registerBlocking=8,32 '" ],
       "extensions": [ ]
     }
   }},
@@ -36,28 +36,28 @@
       "type": "MLIR",
       "benchmark": "pytorch/torch-dynamo-mlp-fp32-3x1024.mlir",
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16  --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16  --vector-to-kernels --registerBlocking=8,32 '" ],
       "extensions": [ ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "MLIR",
       "benchmark": "pytorch/torch-dynamo-mlp-fp32-3x1024.mlir",
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8  --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8  --vector-to-kernels --registerBlocking=8,32 '" ],
       "extensions": [ ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "MLIR",
       "benchmark": "pytorch/torch-dynamo-mlp-fp32-3x1024.mlir",
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8  --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8  --vector-to-kernels --registerBlocking=8,32 '" ],
       "extensions": [ ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "MLIR",
       "benchmark": "pytorch/torch-dynamo-mlp-fp32-3x1024.mlir",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8  --vector-to-kernels --lhsTile=4,32 --rhsTile=32,1'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8  --vector-to-kernels --registerBlocking=8,32 '" ],
       "extensions": [ ]
     }
   }}

--- a/include/TPP/PassBundles.td
+++ b/include/TPP/PassBundles.td
@@ -47,10 +47,8 @@ def DefaultTppPasses : Pass<"default-tpp-passes", "ModuleOp"> {
     Option<"lowerPackUnpackWithoutTranspose", "lower-pack-unpack-without-transpose",
            "bool", /*default=*/"false",
            "Lower non-constant packs and unpacks reverting any dim permutations.">,
-    ListOption<"lhsTile", "lhsTile",
-           "unsigned", "Lhs tile size for brgemm operation.">,
-    ListOption<"rhsTile", "rhsTile",
-           "unsigned", "Rhs tile size for brgemm operation.">,
+    ListOption<"registerBlocking", "registerBlocking",
+           "unsigned", "Register blocking tile sizes for brgemm operation.">,
 
   ];
 }

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -92,14 +92,13 @@ def VectorContractToFMA : Pass<
 def BrgemmLinalgTiling : Pass<"tile-brgemm-linalg"> {
   let summary = "Tile bregmm  matmul and reduction dimension.";
   let description = [{
-    Tiles the innermost dimensions of the batch reduce matmul operation. Additionally, it swaps the reduction and k dimension loop. The final loop structure is as follows: M-loop->N-loop->reduction-loop->K-loop. For example: --tile-brgemm-linalg="lhsTile=8,8 rhsTile=8,16".
+    Tiles the innermost dimensions of the batch reduce matmul operation to support perfect register allocation. Additionally, it swaps the reduction and k dimension loop. The final loop structure is as follows: M-loop->N-loop->reduction-loop->K-loop. For example: --tile-brgemm-linalg="registerBlocking=<mTileSize>, <nTileSize>".
   }];
   let dependentDialects = ["linalg::LinalgDialect",
                            "memref::MemRefDialect",
                            "arith::ArithDialect"];
   let options = [
-         ListOption<"mTileShape", "lhsTile", "unsigned", "Input for the tile shape of m x k dim. Tile size should not be greater than the dimension size. Example: lhsTile=8,8">,
-         ListOption<"nTileShape", "rhsTile", "unsigned", "Input for the tile shape of k x n dim. Tile size should not be greater than the dimension size. Example: rhsTile=8,16">,
+         ListOption<"registerTileShape", "registerBlocking", "unsigned", "Input for the register blocking tile shapes for a brgemm operation">,
   ];
 }
 

--- a/lib/TPP/DefaultPipeline.cpp
+++ b/lib/TPP/DefaultPipeline.cpp
@@ -66,17 +66,12 @@ llvm::cl::opt<bool> lowerPackUnpackWithoutTranspose(
     llvm::cl::desc("Lower packs and unpacks reverting any dim permutations"),
     llvm::cl::init(false));
 
-// Lhs tile sizes for linalg-to-vector.
+
 llvm::cl::list<unsigned>
-    lhsTile("lhsTile", llvm::cl::desc("Lhs tile size for brgemm operation"),
-            llvm::cl::list_init<unsigned>(SmallVector<unsigned>{8, 8}),
+    registerBlocking("registerBlocking", llvm::cl::desc("Register blocking tile sizes for brgemm operation"),
+            llvm::cl::list_init<unsigned>(SmallVector<unsigned>{8, 32}),
             llvm::cl::CommaSeparated);
 
-// Rhs tile sizes for linalg-to-vector
-llvm::cl::list<unsigned>
-    rhsTile("rhsTile", llvm::cl::desc("Rhs tile size for brgemm operation"),
-            llvm::cl::list_init<unsigned>(SmallVector<unsigned>{8, 16}),
-            llvm::cl::CommaSeparated);
 
 llvm::cl::opt<bool> vectorToXSMM("vector-to-XSMM",
                                  llvm::cl::desc("Lower vector to XSMM"),
@@ -160,10 +155,8 @@ private:
       tppDefaultOptions.linalgToVector = linalgToVector;
       tppDefaultOptions.vectorToXSMM = vectorToXSMM;
       tppDefaultOptions.lowerPackUnpackWithoutTranspose = lowerPackUnpackWithoutTranspose;
-      tppDefaultOptions.lhsTile =
-          SmallVector<unsigned>{lhsTile.begin(), lhsTile.end()};
-      tppDefaultOptions.rhsTile =
-          SmallVector<unsigned>{rhsTile.begin(), rhsTile.end()};
+      tppDefaultOptions.registerBlocking =
+          SmallVector<unsigned>{registerBlocking.begin(), registerBlocking.end()};
       tppDefaultOptions.vectorToKernel = vectorToKernel;
 
       pm.addPass(createDefaultTppPasses(tppDefaultOptions));

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -139,8 +139,7 @@ private:
       if (linalgToVector || forceLinalgToVector) {
         // Vectorizes the remaining Linalg operations
         pm.addNestedPass<func::FuncOp>(createBrgemmLinalgTiling(
-            BrgemmLinalgTilingOptions{SmallVector<unsigned>{*lhsTile},
-                                      SmallVector<unsigned>{*rhsTile}}));
+            BrgemmLinalgTilingOptions{SmallVector<unsigned>{*registerBlocking}}));
         pm.addNestedPass<func::FuncOp>(createLoopInvariantCodeMotionPass());
         pm.addNestedPass<func::FuncOp>(createVectorizationPass());
 

--- a/lib/TPP/Transforms/BrgemmLinalgTiling.cpp
+++ b/lib/TPP/Transforms/BrgemmLinalgTiling.cpp
@@ -54,17 +54,17 @@ struct LinalgOpTiling : OpRewritePattern<linalg::BatchReduceMatmulOp> {
 
     if (!brgemmOp.hasPureBufferSemantics())
       return failure();
-    //  Get the M and N tile shape from the user input
-    SmallVector<int64_t> tileShapeM(options.mTileShape.begin(),
-                                    options.mTileShape.end());
-    SmallVector<int64_t> tileShapeN(options.nTileShape.begin(),
-                                    options.nTileShape.end());
+    //  Get the register blocking tile shape from the user input
+    SmallVector<int64_t> tileShapeM(options.registerTileShape.begin(),
+                                    options.registerTileShape.end());
 
-    if (tileShapeM.size() != 2 || tileShapeN.size() != 2)
+    SmallVector<int64_t> tileShapeN(2);
+    tileShapeN[0] = 1;
+    tileShapeN[1] = tileShapeM[1];
+    tileShapeM[1] = 1;
+
+    if (tileShapeM.size() != 2)
            return failure();
-
-    if (tileShapeM[1] != tileShapeN[0])
-            return failure();
 
     // Stores the M, N, and K Tile Sizes
     SmallVector<int64_t> mxnxkTile(3);
@@ -114,8 +114,8 @@ struct LinalgOpTiling : OpRewritePattern<linalg::BatchReduceMatmulOp> {
       Value ubCstTiledLoop = rewriter.create<arith::ConstantIndexOp>(loc, upperBound);
       //Tile size should not be greater than the upperBound
       if ((*itrShapeM) > upperBound)
-	      return failure();
-      Value stepCstTiledLoop = rewriter.create<arith::ConstantIndexOp>(loc, upperBound/(*itrShapeM));
+              return failure();
+      Value stepCstTiledLoop = rewriter.create<arith::ConstantIndexOp>(loc, *itrShapeM);
       // Creates M, N, and K tile loops
       scf::ForOp loopOp = rewriter.create<scf::ForOp>(brgemmOp.getLoc(),
                                                       zeroCst, ubCstTiledLoop, stepCstTiledLoop);
@@ -184,8 +184,8 @@ struct LinalgOpTiling : OpRewritePattern<linalg::BatchReduceMatmulOp> {
             strides.push_back(rewriter.getIndexAttr(1));
           }
         } else {
-          shape.push_back(rewriter.getIndexAttr(tensorShape[j] / (*tileItr)));
-          indices.push_back(tensorShape[j] / (*tileItr));
+          shape.push_back(rewriter.getIndexAttr( (*tileItr)));
+          indices.push_back((*tileItr));
           strides.push_back(rewriter.getIndexAttr(1));
           offsets.push_back(
               inductionVars[i][tensorShape.size() - tileSizesIndex[i] + k]);
@@ -224,8 +224,7 @@ struct BrgemmLinalgTiling : public tpp::impl::BrgemmLinalgTilingBase<BrgemmLinal
 
   void runOnOperation() override {
     BrgemmLinalgTilingOptions options;
-    options.mTileShape = SmallVector<unsigned>{*mTileShape};
-    options.nTileShape = SmallVector<unsigned>{*nTileShape};
+    options.registerTileShape = SmallVector<unsigned>{*registerTileShape};
     RewritePatternSet patterns(&getContext());
     populateBrgemmLinalgTilingPatterns(patterns, options);
     GreedyRewriteConfig config;

--- a/lib/TPP/Transforms/BrgemmLinalgTiling.cpp
+++ b/lib/TPP/Transforms/BrgemmLinalgTiling.cpp
@@ -58,13 +58,13 @@ struct LinalgOpTiling : OpRewritePattern<linalg::BatchReduceMatmulOp> {
     SmallVector<int64_t> tileShapeM(options.registerTileShape.begin(),
                                     options.registerTileShape.end());
 
+    if (tileShapeM.size() != 2)
+           return failure();
+
     SmallVector<int64_t> tileShapeN(2);
     tileShapeN[0] = 1;
     tileShapeN[1] = tileShapeM[1];
     tileShapeM[1] = 1;
-
-    if (tileShapeM.size() != 2)
-           return failure();
 
     // Stores the M, N, and K Tile Sizes
     SmallVector<int64_t> mxnxkTile(3);
@@ -184,7 +184,7 @@ struct LinalgOpTiling : OpRewritePattern<linalg::BatchReduceMatmulOp> {
             strides.push_back(rewriter.getIndexAttr(1));
           }
         } else {
-          shape.push_back(rewriter.getIndexAttr( (*tileItr)));
+          shape.push_back(rewriter.getIndexAttr(*tileItr));
           indices.push_back((*tileItr));
           strides.push_back(rewriter.getIndexAttr(1));
           offsets.push_back(

--- a/test/Integration/tile-brgemm-linalg-matmul.mlir
+++ b/test/Integration/tile-brgemm-linalg-matmul.mlir
@@ -1,8 +1,8 @@
 // RUN: tpp-run -e entry --entry-point-result=void -print %s > %t.1
 // RUN: tpp-run -e entry --entry-point-result=void --vector-to-kernels --registerBlocking=8,32 %s -print > %t.2
-// RUN: diff %t.1 %t.2 | FileCheck %s --check-prefix=DIFF --allow-empty
+// RUN: diff %t.1 %t.2
+// RUN: rm %t.1 %t.2
 
-// DIFF-NOT: {{.}}
 module {
   memref.global "private" constant @__constant_48x32x32xf32 : memref<48x32x32xf32> = dense<1.000000e+00> {alignment = 64 : i64}
   func.func @entry(%arg0: memref<8x48x32x32xf32>) -> memref<8x48x32x32xf32> {

--- a/test/Integration/tile-brgemm-linalg-matmul.mlir
+++ b/test/Integration/tile-brgemm-linalg-matmul.mlir
@@ -1,5 +1,5 @@
-// RUN: tpp-opt %s  | tpp-run -e entry --entry-point-result=void -print > %t.1
-// RUN: tpp-opt %s  --tile-brgemm-linalg="registerBlocking=8,32" --vectorization-pass| tpp-run -e entry --entry-point-result=void -print > %t.2
+// RUN: tpp-run -e entry --entry-point-result=void -print %s > %t.1
+// RUN: tpp-run -e entry --entry-point-result=void --vector-to-kernels --registerBlocking=8,32 %s -print > %t.2
 // RUN: diff %t.1 %t.2 | FileCheck %s --check-prefix=DIFF --allow-empty
 
 // DIFF-NOT: {{.}}

--- a/test/Integration/tile-brgemm-linalg-matmul.mlir
+++ b/test/Integration/tile-brgemm-linalg-matmul.mlir
@@ -1,5 +1,5 @@
 // RUN: tpp-opt %s  | tpp-run -e entry --entry-point-result=void -print > %t.1
-// RUN: tpp-opt %s  --tile-brgemm-linalg="lhsTile=8,8 rhsTile=8,16" --vectorization-pass| tpp-run -e entry --entry-point-result=void -print > %t.2
+// RUN: tpp-opt %s  --tile-brgemm-linalg="registerBlocking=8,32" --vectorization-pass| tpp-run -e entry --entry-point-result=void -print > %t.2
 // RUN: diff %t.1 %t.2 | FileCheck %s --check-prefix=DIFF --allow-empty
 
 // DIFF-NOT: {{.}}

--- a/test/Passes/pass-tile-brgemm-linalg-matmul.mlir
+++ b/test/Passes/pass-tile-brgemm-linalg-matmul.mlir
@@ -1,8 +1,8 @@
 
-// RUN: tpp-opt %s --tile-brgemm-linalg="lhsTile=8,8 rhsTile=8,16" --split-input-file  | FileCheck %s
+// RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=8,32" --split-input-file  | FileCheck %s
 
 module {
-  func.func @entry(%arg0: memref<16x32x16x32xf32>, %arg1: memref<32x32x32x32xf32>, %arg2: memref<16x32x16x32xf32>) {
+  func.func @gemm_do_register_tiling(%arg0: memref<16x32x16x32xf32>, %arg1: memref<32x32x32x32xf32>, %arg2: memref<16x32x16x32xf32>) {
     scf.forall (%arg3, %arg4) in (16, 32) {
       %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 32, 16, 32] [1, 1, 1, 1] : memref<16x32x16x32xf32> to memref<32x16x32xf32, strided<[512, 32, 1], offset: ?>>
       %subview_0 = memref.subview %arg1[%arg4, 0, 0, 0] [1, 32, 32, 32] [1, 1, 1, 1] : memref<32x32x32x32xf32> to memref<32x32x32xf32, strided<[1024, 32, 1], offset: ?>>
@@ -13,30 +13,27 @@ module {
   }
 }
 
-
-
-// CHECK-LABEL:   func.func @entry(
+// CHECK-LABEL:   func.func @gemm_do_register_tiling(
 // CHECK-SAME:                     %[[VAL_0:.*]]: memref<16x32x16x32xf32>,
 // CHECK-SAME:                     %[[VAL_1:.*]]: memref<32x32x32x32xf32>,
 // CHECK-SAME:                     %[[VAL_2:.*]]: memref<16x32x16x32xf32>) {
-// CHECK:           %[[VAL_3:.*]] = arith.constant 4 : index
-// CHECK:           %[[VAL_4:.*]] = arith.constant 1 : index
-// CHECK:           %[[VAL_5:.*]] = arith.constant 32 : index
-// CHECK:           %[[VAL_6:.*]] = arith.constant 2 : index
-// CHECK:           %[[VAL_7:.*]] = arith.constant 16 : index
-// CHECK:           %[[VAL_8:.*]] = arith.constant 0 : index
-// CHECK:           scf.forall (%[[VAL_9:.*]], %[[VAL_10:.*]]) in (16, 32) {
-// CHECK:             %[[VAL_11:.*]] = memref.subview %[[VAL_0]]{{\[}}%[[VAL_9]], 0, 0, 0] [1, 32, 16, 32] [1, 1, 1, 1] : memref<16x32x16x32xf32> to memref<32x16x32xf32, strided<[512, 32, 1], offset: ?>>
-// CHECK:             %[[VAL_12:.*]] = memref.subview %[[VAL_1]]{{\[}}%[[VAL_10]], 0, 0, 0] [1, 32, 32, 32] [1, 1, 1, 1] : memref<32x32x32x32xf32> to memref<32x32x32xf32, strided<[1024, 32, 1], offset: ?>>
-// CHECK:             %[[VAL_13:.*]] = memref.subview %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]], 0, 0] [1, 1, 16, 32] [1, 1, 1, 1] : memref<16x32x16x32xf32> to memref<16x32xf32, strided<[32, 1], offset: ?>>
-// CHECK:             scf.for %[[VAL_14:.*]] = %[[VAL_8]] to %[[VAL_7]] step %[[VAL_6]] {
-// CHECK:               scf.for %[[VAL_15:.*]] = %[[VAL_8]] to %[[VAL_5]] step %[[VAL_6]] {
-// CHECK:                 scf.for %[[VAL_16:.*]] = %[[VAL_8]] to %[[VAL_5]] step %[[VAL_4]] {
-// CHECK:                   scf.for %[[VAL_17:.*]] = %[[VAL_8]] to %[[VAL_5]] step %[[VAL_3]] {
-// CHECK:                     %[[VAL_18:.*]] = memref.subview %[[VAL_11]]{{\[}}%[[VAL_16]], %[[VAL_14]], %[[VAL_17]]] [1, 2, 4] [1, 1, 1] : memref<32x16x32xf32, strided<[512, 32, 1], offset: ?>> to memref<1x2x4xf32, strided<[512, 32, 1], offset: ?>>
-// CHECK:                     %[[VAL_19:.*]] = memref.subview %[[VAL_12]]{{\[}}%[[VAL_16]], %[[VAL_17]], %[[VAL_15]]] [1, 4, 2] [1, 1, 1] : memref<32x32x32xf32, strided<[1024, 32, 1], offset: ?>> to memref<1x4x2xf32, strided<[1024, 32, 1], offset: ?>>
-// CHECK:                     %[[VAL_20:.*]] = memref.subview %[[VAL_13]]{{\[}}%[[VAL_14]], %[[VAL_15]]] [2, 2] [1, 1] : memref<16x32xf32, strided<[32, 1], offset: ?>> to memref<2x2xf32, strided<[32, 1], offset: ?>>
-// CHECK:                     linalg.batch_reduce_matmul ins(%[[VAL_18]], %[[VAL_19]] : memref<1x2x4xf32, strided<[512, 32, 1], offset: ?>>, memref<1x4x2xf32, strided<[1024, 32, 1], offset: ?>>) outs(%[[VAL_20]] : memref<2x2xf32, strided<[32, 1], offset: ?>>)
+// CHECK:           %[[VAL_3:.*]] = arith.constant 1 : index
+// CHECK:           %[[VAL_4:.*]] = arith.constant 32 : index
+// CHECK:           %[[VAL_5:.*]] = arith.constant 8 : index
+// CHECK:           %[[VAL_6:.*]] = arith.constant 16 : index
+// CHECK:           %[[VAL_7:.*]] = arith.constant 0 : index
+// CHECK:           scf.forall (%[[VAL_8:.*]], %[[VAL_9:.*]]) in (16, 32) {
+// CHECK:             %[[VAL_10:.*]] = memref.subview %[[VAL_0]]{{\[}}%[[VAL_8]], 0, 0, 0] [1, 32, 16, 32] [1, 1, 1, 1] : memref<16x32x16x32xf32> to memref<32x16x32xf32, strided<[512, 32, 1], offset: ?>>
+// CHECK:             %[[VAL_11:.*]] = memref.subview %[[VAL_1]]{{\[}}%[[VAL_9]], 0, 0, 0] [1, 32, 32, 32] [1, 1, 1, 1] : memref<32x32x32x32xf32> to memref<32x32x32xf32, strided<[1024, 32, 1], offset: ?>>
+// CHECK:             %[[VAL_12:.*]] = memref.subview %[[VAL_2]]{{\[}}%[[VAL_8]], %[[VAL_9]], 0, 0] [1, 1, 16, 32] [1, 1, 1, 1] : memref<16x32x16x32xf32> to memref<16x32xf32, strided<[32, 1], offset: ?>>
+// CHECK:             scf.for %[[VAL_13:.*]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_5]] {
+// CHECK:               scf.for %[[VAL_14:.*]] = %[[VAL_7]] to %[[VAL_4]] step %[[VAL_4]] {
+// CHECK:                 scf.for %[[VAL_15:.*]] = %[[VAL_7]] to %[[VAL_4]] step %[[VAL_3]] {
+// CHECK:                   scf.for %[[VAL_16:.*]] = %[[VAL_7]] to %[[VAL_4]] step %[[VAL_3]] {
+// CHECK:                     %[[VAL_17:.*]] = memref.subview %[[VAL_10]]{{\[}}%[[VAL_15]], %[[VAL_13]], %[[VAL_16]]] [1, 8, 1] [1, 1, 1] : memref<32x16x32xf32, strided<[512, 32, 1], offset: ?>> to memref<1x8x1xf32, strided<[512, 32, 1], offset: ?>>
+// CHECK:                     %[[VAL_18:.*]] = memref.subview %[[VAL_11]]{{\[}}%[[VAL_15]], %[[VAL_16]], %[[VAL_14]]] [1, 1, 32] [1, 1, 1] : memref<32x32x32xf32, strided<[1024, 32, 1], offset: ?>> to memref<1x1x32xf32, strided<[1024, 32, 1], offset: ?>>
+// CHECK:                     %[[VAL_19:.*]] = memref.subview %[[VAL_12]]{{\[}}%[[VAL_13]], %[[VAL_14]]] [8, 32] [1, 1] : memref<16x32xf32, strided<[32, 1], offset: ?>> to memref<8x32xf32, strided<[32, 1], offset: ?>>
+// CHECK:                     linalg.batch_reduce_matmul ins(%[[VAL_17]], %[[VAL_18]] : memref<1x8x1xf32, strided<[512, 32, 1], offset: ?>>, memref<1x1x32xf32, strided<[1024, 32, 1], offset: ?>>) outs(%[[VAL_19]] : memref<8x32xf32, strided<[32, 1], offset: ?>>)
 // CHECK:                   }
 // CHECK:                 }
 // CHECK:               }
@@ -47,12 +44,11 @@ module {
 
 // -----
 
-
-// RUN: tpp-opt %s --tile-brgemm-linalg="lhsTile=8,8 rhsTile=8,16" --split-input-file | FileCheck %s
+// RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=8,32" --split-input-file | FileCheck %s
 
 module {
   memref.global "private" constant @__constant_48x32x32xf32 : memref<48x32x32xf32> = dense<1.000000e+00> {alignment = 64 : i64}
-  func.func @entry(%arg0: memref<8x48x32x32xf32>) -> memref<8x48x32x32xf32> {
+  func.func @chainned_gemm_do_register_tiling(%arg0: memref<8x48x32x32xf32>) -> memref<8x48x32x32xf32> {
     %cst = arith.constant 0.000000e+00 : f32
     %0 = memref.get_global @__constant_48x32x32xf32 : memref<48x32x32xf32>
     %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x48x32x32xf32>
@@ -79,72 +75,69 @@ module {
   }
 }
 
-
-
 // CHECK-LABEL:   memref.global "private" constant @__constant_48x32x32xf32 : memref<48x32x32xf32> = dense<1.000000e+00> {alignment = 64 : i64}
 
-// CHECK-LABEL:   func.func @entry(
+// CHECK-LABEL:   func.func @chainned_gemm_do_register_tiling(
 // CHECK-SAME:                     %[[VAL_0:.*]]: memref<8x48x32x32xf32>) -> memref<8x48x32x32xf32> {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
 // CHECK:           %[[VAL_2:.*]] = arith.constant 48 : index
-// CHECK:           %[[VAL_3:.*]] = arith.constant 2 : index
-// CHECK:           %[[VAL_4:.*]] = arith.constant 4 : index
-// CHECK:           %[[VAL_5:.*]] = arith.constant 32 : index
-// CHECK:           %[[VAL_6:.*]] = arith.constant 0 : index
-// CHECK:           %[[VAL_7:.*]] = arith.constant 0.000000e+00 : f32
-// CHECK:           %[[VAL_8:.*]] = memref.get_global @__constant_48x32x32xf32 : memref<48x32x32xf32>
-// CHECK:           %[[VAL_9:.*]] = memref.alloc() {alignment = 64 : i64} : memref<8x48x32x32xf32>
-// CHECK:           scf.forall (%[[VAL_10:.*]], %[[VAL_11:.*]]) in (8, 48) {
-// CHECK:             %[[VAL_12:.*]] = memref.subview %[[VAL_9]]{{\[}}%[[VAL_10]], %[[VAL_11]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x48x32x32xf32> to memref<32x32xf32, strided<[32, 1], offset: ?>>
-// CHECK:             linalg.fill ins(%[[VAL_7]] : f32) outs(%[[VAL_12]] : memref<32x32xf32, strided<[32, 1], offset: ?>>)
-// CHECK:             %[[VAL_13:.*]] = memref.subview %[[VAL_0]]{{\[}}%[[VAL_10]], 0, 0, 0] [1, 48, 32, 32] [1, 1, 1, 1] : memref<8x48x32x32xf32> to memref<48x32x32xf32, strided<[1024, 32, 1], offset: ?>>
-// CHECK:             scf.for %[[VAL_14:.*]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_4]] {
-// CHECK:               scf.for %[[VAL_15:.*]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_3]] {
-// CHECK:                 scf.for %[[VAL_16:.*]] = %[[VAL_6]] to %[[VAL_2]] step %[[VAL_1]] {
-// CHECK:                   scf.for %[[VAL_17:.*]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_4]] {
-// CHECK:                     %[[VAL_18:.*]] = memref.subview %[[VAL_13]]{{\[}}%[[VAL_16]], %[[VAL_14]], %[[VAL_17]]] [1, 4, 4] [1, 1, 1] : memref<48x32x32xf32, strided<[1024, 32, 1], offset: ?>> to memref<1x4x4xf32, strided<[1024, 32, 1], offset: ?>>
-// CHECK:                     %[[VAL_19:.*]] = memref.subview %[[VAL_8]]{{\[}}%[[VAL_16]], %[[VAL_17]], %[[VAL_15]]] [1, 4, 2] [1, 1, 1] : memref<48x32x32xf32> to memref<1x4x2xf32, strided<[1024, 32, 1], offset: ?>>
-// CHECK:                     %[[VAL_20:.*]] = memref.subview %[[VAL_12]]{{\[}}%[[VAL_14]], %[[VAL_15]]] [4, 2] [1, 1] : memref<32x32xf32, strided<[32, 1], offset: ?>> to memref<4x2xf32, strided<[32, 1], offset: ?>>
-// CHECK:                     linalg.batch_reduce_matmul ins(%[[VAL_18]], %[[VAL_19]] : memref<1x4x4xf32, strided<[1024, 32, 1], offset: ?>>, memref<1x4x2xf32, strided<[1024, 32, 1], offset: ?>>) outs(%[[VAL_20]] : memref<4x2xf32, strided<[32, 1], offset: ?>>)
+// CHECK:           %[[VAL_3:.*]] = arith.constant 8 : index
+// CHECK:           %[[VAL_4:.*]] = arith.constant 32 : index
+// CHECK:           %[[VAL_5:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_6:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_7:.*]] = memref.get_global @__constant_48x32x32xf32 : memref<48x32x32xf32>
+// CHECK:           %[[VAL_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<8x48x32x32xf32>
+// CHECK:           scf.forall (%[[VAL_9:.*]], %[[VAL_10:.*]]) in (8, 48) {
+// CHECK:             %[[VAL_11:.*]] = memref.subview %[[VAL_8]]{{\[}}%[[VAL_9]], %[[VAL_10]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x48x32x32xf32> to memref<32x32xf32, strided<[32, 1], offset: ?>>
+// CHECK:             linalg.fill ins(%[[VAL_6]] : f32) outs(%[[VAL_11]] : memref<32x32xf32, strided<[32, 1], offset: ?>>)
+// CHECK:             %[[VAL_12:.*]] = memref.subview %[[VAL_0]]{{\[}}%[[VAL_9]], 0, 0, 0] [1, 48, 32, 32] [1, 1, 1, 1] : memref<8x48x32x32xf32> to memref<48x32x32xf32, strided<[1024, 32, 1], offset: ?>>
+// CHECK:             scf.for %[[VAL_13:.*]] = %[[VAL_5]] to %[[VAL_4]] step %[[VAL_3]] {
+// CHECK:               scf.for %[[VAL_14:.*]] = %[[VAL_5]] to %[[VAL_4]] step %[[VAL_4]] {
+// CHECK:                 scf.for %[[VAL_15:.*]] = %[[VAL_5]] to %[[VAL_2]] step %[[VAL_1]] {
+// CHECK:                   scf.for %[[VAL_16:.*]] = %[[VAL_5]] to %[[VAL_4]] step %[[VAL_1]] {
+// CHECK:                     %[[VAL_17:.*]] = memref.subview %[[VAL_12]]{{\[}}%[[VAL_15]], %[[VAL_13]], %[[VAL_16]]] [1, 8, 1] [1, 1, 1] : memref<48x32x32xf32, strided<[1024, 32, 1], offset: ?>> to memref<1x8x1xf32, strided<[1024, 32, 1], offset: ?>>
+// CHECK:                     %[[VAL_18:.*]] = memref.subview %[[VAL_7]]{{\[}}%[[VAL_15]], %[[VAL_16]], %[[VAL_14]]] [1, 1, 32] [1, 1, 1] : memref<48x32x32xf32> to memref<1x1x32xf32, strided<[1024, 32, 1], offset: ?>>
+// CHECK:                     %[[VAL_19:.*]] = memref.subview %[[VAL_11]]{{\[}}%[[VAL_13]], %[[VAL_14]]] [8, 32] [1, 1] : memref<32x32xf32, strided<[32, 1], offset: ?>> to memref<8x32xf32, strided<[32, 1], offset: ?>>
+// CHECK:                     linalg.batch_reduce_matmul ins(%[[VAL_17]], %[[VAL_18]] : memref<1x8x1xf32, strided<[1024, 32, 1], offset: ?>>, memref<1x1x32xf32, strided<[1024, 32, 1], offset: ?>>) outs(%[[VAL_19]] : memref<8x32xf32, strided<[32, 1], offset: ?>>)
 // CHECK:                   }
 // CHECK:                 }
 // CHECK:               }
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_21:.*]] = memref.alloc() {alignment = 64 : i64} : memref<8x48x32x32xf32>
-// CHECK:           scf.forall (%[[VAL_22:.*]], %[[VAL_23:.*]]) in (8, 48) {
-// CHECK:             %[[VAL_24:.*]] = memref.subview %[[VAL_21]]{{\[}}%[[VAL_22]], %[[VAL_23]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x48x32x32xf32> to memref<32x32xf32, strided<[32, 1], offset: ?>>
-// CHECK:             linalg.fill ins(%[[VAL_7]] : f32) outs(%[[VAL_24]] : memref<32x32xf32, strided<[32, 1], offset: ?>>)
-// CHECK:             %[[VAL_25:.*]] = memref.subview %[[VAL_9]]{{\[}}%[[VAL_22]], 0, 0, 0] [1, 48, 32, 32] [1, 1, 1, 1] : memref<8x48x32x32xf32> to memref<48x32x32xf32, strided<[1024, 32, 1], offset: ?>>
-// CHECK:             scf.for %[[VAL_26:.*]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_4]] {
-// CHECK:               scf.for %[[VAL_27:.*]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_3]] {
-// CHECK:                 scf.for %[[VAL_28:.*]] = %[[VAL_6]] to %[[VAL_2]] step %[[VAL_1]] {
-// CHECK:                   scf.for %[[VAL_29:.*]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_4]] {
-// CHECK:                     %[[VAL_30:.*]] = memref.subview %[[VAL_25]]{{\[}}%[[VAL_28]], %[[VAL_26]], %[[VAL_29]]] [1, 4, 4] [1, 1, 1] : memref<48x32x32xf32, strided<[1024, 32, 1], offset: ?>> to memref<1x4x4xf32, strided<[1024, 32, 1], offset: ?>>
-// CHECK:                     %[[VAL_31:.*]] = memref.subview %[[VAL_8]]{{\[}}%[[VAL_28]], %[[VAL_29]], %[[VAL_27]]] [1, 4, 2] [1, 1, 1] : memref<48x32x32xf32> to memref<1x4x2xf32, strided<[1024, 32, 1], offset: ?>>
-// CHECK:                     %[[VAL_32:.*]] = memref.subview %[[VAL_24]]{{\[}}%[[VAL_26]], %[[VAL_27]]] [4, 2] [1, 1] : memref<32x32xf32, strided<[32, 1], offset: ?>> to memref<4x2xf32, strided<[32, 1], offset: ?>>
-// CHECK:                     linalg.batch_reduce_matmul ins(%[[VAL_30]], %[[VAL_31]] : memref<1x4x4xf32, strided<[1024, 32, 1], offset: ?>>, memref<1x4x2xf32, strided<[1024, 32, 1], offset: ?>>) outs(%[[VAL_32]] : memref<4x2xf32, strided<[32, 1], offset: ?>>)
+// CHECK:           %[[VAL_20:.*]] = memref.alloc() {alignment = 64 : i64} : memref<8x48x32x32xf32>
+// CHECK:           scf.forall (%[[VAL_21:.*]], %[[VAL_22:.*]]) in (8, 48) {
+// CHECK:             %[[VAL_23:.*]] = memref.subview %[[VAL_20]]{{\[}}%[[VAL_21]], %[[VAL_22]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x48x32x32xf32> to memref<32x32xf32, strided<[32, 1], offset: ?>>
+// CHECK:             linalg.fill ins(%[[VAL_6]] : f32) outs(%[[VAL_23]] : memref<32x32xf32, strided<[32, 1], offset: ?>>)
+// CHECK:             %[[VAL_24:.*]] = memref.subview %[[VAL_8]]{{\[}}%[[VAL_21]], 0, 0, 0] [1, 48, 32, 32] [1, 1, 1, 1] : memref<8x48x32x32xf32> to memref<48x32x32xf32, strided<[1024, 32, 1], offset: ?>>
+// CHECK:             scf.for %[[VAL_25:.*]] = %[[VAL_5]] to %[[VAL_4]] step %[[VAL_3]] {
+// CHECK:               scf.for %[[VAL_26:.*]] = %[[VAL_5]] to %[[VAL_4]] step %[[VAL_4]] {
+// CHECK:                 scf.for %[[VAL_27:.*]] = %[[VAL_5]] to %[[VAL_2]] step %[[VAL_1]] {
+// CHECK:                   scf.for %[[VAL_28:.*]] = %[[VAL_5]] to %[[VAL_4]] step %[[VAL_1]] {
+// CHECK:                     %[[VAL_29:.*]] = memref.subview %[[VAL_24]]{{\[}}%[[VAL_27]], %[[VAL_25]], %[[VAL_28]]] [1, 8, 1] [1, 1, 1] : memref<48x32x32xf32, strided<[1024, 32, 1], offset: ?>> to memref<1x8x1xf32, strided<[1024, 32, 1], offset: ?>>
+// CHECK:                     %[[VAL_30:.*]] = memref.subview %[[VAL_7]]{{\[}}%[[VAL_27]], %[[VAL_28]], %[[VAL_26]]] [1, 1, 32] [1, 1, 1] : memref<48x32x32xf32> to memref<1x1x32xf32, strided<[1024, 32, 1], offset: ?>>
+// CHECK:                     %[[VAL_31:.*]] = memref.subview %[[VAL_23]]{{\[}}%[[VAL_25]], %[[VAL_26]]] [8, 32] [1, 1] : memref<32x32xf32, strided<[32, 1], offset: ?>> to memref<8x32xf32, strided<[32, 1], offset: ?>>
+// CHECK:                     linalg.batch_reduce_matmul ins(%[[VAL_29]], %[[VAL_30]] : memref<1x8x1xf32, strided<[1024, 32, 1], offset: ?>>, memref<1x1x32xf32, strided<[1024, 32, 1], offset: ?>>) outs(%[[VAL_31]] : memref<8x32xf32, strided<[32, 1], offset: ?>>)
 // CHECK:                   }
 // CHECK:                 }
 // CHECK:               }
 // CHECK:             }
 // CHECK:           }
-// CHECK:           scf.forall (%[[VAL_33:.*]], %[[VAL_34:.*]]) in (8, 48) {
-// CHECK:             %[[VAL_35:.*]] = memref.subview %[[VAL_9]]{{\[}}%[[VAL_33]], %[[VAL_34]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x48x32x32xf32> to memref<32x32xf32, strided<[32, 1], offset: ?>>
-// CHECK:             linalg.fill ins(%[[VAL_7]] : f32) outs(%[[VAL_35]] : memref<32x32xf32, strided<[32, 1], offset: ?>>)
-// CHECK:             %[[VAL_36:.*]] = memref.subview %[[VAL_21]]{{\[}}%[[VAL_33]], 0, 0, 0] [1, 48, 32, 32] [1, 1, 1, 1] : memref<8x48x32x32xf32> to memref<48x32x32xf32, strided<[1024, 32, 1], offset: ?>>
-// CHECK:             scf.for %[[VAL_37:.*]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_4]] {
-// CHECK:               scf.for %[[VAL_38:.*]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_3]] {
-// CHECK:                 scf.for %[[VAL_39:.*]] = %[[VAL_6]] to %[[VAL_2]] step %[[VAL_1]] {
-// CHECK:                   scf.for %[[VAL_40:.*]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_4]] {
-// CHECK:                     %[[VAL_41:.*]] = memref.subview %[[VAL_36]]{{\[}}%[[VAL_39]], %[[VAL_37]], %[[VAL_40]]] [1, 4, 4] [1, 1, 1] : memref<48x32x32xf32, strided<[1024, 32, 1], offset: ?>> to memref<1x4x4xf32, strided<[1024, 32, 1], offset: ?>>
-// CHECK:                     %[[VAL_42:.*]] = memref.subview %[[VAL_8]]{{\[}}%[[VAL_39]], %[[VAL_40]], %[[VAL_38]]] [1, 4, 2] [1, 1, 1] : memref<48x32x32xf32> to memref<1x4x2xf32, strided<[1024, 32, 1], offset: ?>>
-// CHECK:                     %[[VAL_43:.*]] = memref.subview %[[VAL_35]]{{\[}}%[[VAL_37]], %[[VAL_38]]] [4, 2] [1, 1] : memref<32x32xf32, strided<[32, 1], offset: ?>> to memref<4x2xf32, strided<[32, 1], offset: ?>>
-// CHECK:                     linalg.batch_reduce_matmul ins(%[[VAL_41]], %[[VAL_42]] : memref<1x4x4xf32, strided<[1024, 32, 1], offset: ?>>, memref<1x4x2xf32, strided<[1024, 32, 1], offset: ?>>) outs(%[[VAL_43]] : memref<4x2xf32, strided<[32, 1], offset: ?>>)
+// CHECK:           scf.forall (%[[VAL_32:.*]], %[[VAL_33:.*]]) in (8, 48) {
+// CHECK:             %[[VAL_34:.*]] = memref.subview %[[VAL_8]]{{\[}}%[[VAL_32]], %[[VAL_33]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x48x32x32xf32> to memref<32x32xf32, strided<[32, 1], offset: ?>>
+// CHECK:             linalg.fill ins(%[[VAL_6]] : f32) outs(%[[VAL_34]] : memref<32x32xf32, strided<[32, 1], offset: ?>>)
+// CHECK:             %[[VAL_35:.*]] = memref.subview %[[VAL_20]]{{\[}}%[[VAL_32]], 0, 0, 0] [1, 48, 32, 32] [1, 1, 1, 1] : memref<8x48x32x32xf32> to memref<48x32x32xf32, strided<[1024, 32, 1], offset: ?>>
+// CHECK:             scf.for %[[VAL_36:.*]] = %[[VAL_5]] to %[[VAL_4]] step %[[VAL_3]] {
+// CHECK:               scf.for %[[VAL_37:.*]] = %[[VAL_5]] to %[[VAL_4]] step %[[VAL_4]] {
+// CHECK:                 scf.for %[[VAL_38:.*]] = %[[VAL_5]] to %[[VAL_2]] step %[[VAL_1]] {
+// CHECK:                   scf.for %[[VAL_39:.*]] = %[[VAL_5]] to %[[VAL_4]] step %[[VAL_1]] {
+// CHECK:                     %[[VAL_40:.*]] = memref.subview %[[VAL_35]]{{\[}}%[[VAL_38]], %[[VAL_36]], %[[VAL_39]]] [1, 8, 1] [1, 1, 1] : memref<48x32x32xf32, strided<[1024, 32, 1], offset: ?>> to memref<1x8x1xf32, strided<[1024, 32, 1], offset: ?>>
+// CHECK:                     %[[VAL_41:.*]] = memref.subview %[[VAL_7]]{{\[}}%[[VAL_38]], %[[VAL_39]], %[[VAL_37]]] [1, 1, 32] [1, 1, 1] : memref<48x32x32xf32> to memref<1x1x32xf32, strided<[1024, 32, 1], offset: ?>>
+// CHECK:                     %[[VAL_42:.*]] = memref.subview %[[VAL_34]]{{\[}}%[[VAL_36]], %[[VAL_37]]] [8, 32] [1, 1] : memref<32x32xf32, strided<[32, 1], offset: ?>> to memref<8x32xf32, strided<[32, 1], offset: ?>>
+// CHECK:                     linalg.batch_reduce_matmul ins(%[[VAL_40]], %[[VAL_41]] : memref<1x8x1xf32, strided<[1024, 32, 1], offset: ?>>, memref<1x1x32xf32, strided<[1024, 32, 1], offset: ?>>) outs(%[[VAL_42]] : memref<8x32xf32, strided<[32, 1], offset: ?>>)
 // CHECK:                   }
 // CHECK:                 }
 // CHECK:               }
 // CHECK:             }
 // CHECK:           }
-// CHECK:           return %[[VAL_9]] : memref<8x48x32x32xf32>
+// CHECK:           return %[[VAL_8]] : memref<8x48x32x32xf32>
 // CHECK:         }

--- a/test/Passes/pass-tile-brgemm-linalg-matmul.mlir
+++ b/test/Passes/pass-tile-brgemm-linalg-matmul.mlir
@@ -1,4 +1,3 @@
-
 // RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=8,32" --split-input-file  | FileCheck %s
 
 module {
@@ -44,8 +43,6 @@ module {
 
 // -----
 
-// RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=8,32" --split-input-file | FileCheck %s
-
 module {
   memref.global "private" constant @__constant_48x32x32xf32 : memref<48x32x32xf32> = dense<1.000000e+00> {alignment = 64 : i64}
   func.func @chainned_gemm_do_register_tiling(%arg0: memref<8x48x32x32xf32>) -> memref<8x48x32x32xf32> {
@@ -76,7 +73,6 @@ module {
 }
 
 // CHECK-LABEL:   memref.global "private" constant @__constant_48x32x32xf32 : memref<48x32x32xf32> = dense<1.000000e+00> {alignment = 64 : i64}
-
 // CHECK-LABEL:   func.func @chainned_gemm_do_register_tiling(
 // CHECK-SAME:                     %[[VAL_0:.*]]: memref<8x48x32x32xf32>) -> memref<8x48x32x32xf32> {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index


### PR DESCRIPTION
This PR is for two things:
1. Add new benchmarks to test `avx2` and `arm sve` instructions set for `vector-to-kernel` lowering,
2. User input option design change for register tiling. Changes the user options from `lhsTile=<x,y> and rhsTile=<y,z>` to `registerBlocking=<x,z>`