### PR TITLE
Vector contract lowering to bf16dp for brgemm

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -96,6 +96,10 @@ namespace xegpu {
 class XeGPUDialect;
 } // namespace xegpu
 
+namespace x86vector {
+class X86VectorDialect;
+} // namespace x86vector
+
 } // namespace mlir
 
 namespace mlir {

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -103,6 +103,13 @@ def BrgemmLinalgTiling : Pass<"tile-brgemm-linalg"> {
 }
 
 
+def BF16DotProduct : Pass<"vector-contract-to-bf16dp"> {
+   let summary = "Perform avx512bf16 dot product lowering of vector contraction operation for bf16 type with vnni layout=2";
+   let description = [{
+     Perform avx512bf16 dot product lowering of vector contraction operation for bf16 type with vnni layout=2.
+   }];
+   let dependentDialects = [ "vector::VectorDialect", "scf::SCFDialect", "x86vector::X86VectorDialect" ];
+ }
 
 def ConvertXsmmToFunc : Pass<"convert-xsmm-to-func", "ModuleOp"> {
   let summary = "Convert xsmm to func";

--- a/lib/TPP/DefaultPipeline.cpp
+++ b/lib/TPP/DefaultPipeline.cpp
@@ -190,7 +190,9 @@ private:
     // Lower to LLVM
     ConvertVectorToLLVMPassOptions options;
     options.amx = vnni::utils::hasAMX();
-    options.x86Vector = true;
+    #if defined(__x86_64__)
+    	options.x86Vector = true;
+    #endif
     pm.addPass(createConvertVectorToLLVMPass(options));
     pm.addPass(createFinalizeMemRefToLLVMConversionPass());
     pm.addPass(createSCFToControlFlowPass());

--- a/lib/TPP/DefaultPipeline.cpp
+++ b/lib/TPP/DefaultPipeline.cpp
@@ -190,6 +190,7 @@ private:
     // Lower to LLVM
     ConvertVectorToLLVMPassOptions options;
     options.amx = vnni::utils::hasAMX();
+    options.x86Vector = true;
     pm.addPass(createConvertVectorToLLVMPass(options));
     pm.addPass(createFinalizeMemRefToLLVMConversionPass());
     pm.addPass(createSCFToControlFlowPass());

--- a/lib/TPP/PassBundles/VectorToKernel.cpp
+++ b/lib/TPP/PassBundles/VectorToKernel.cpp
@@ -49,6 +49,7 @@ struct VectorToKernel : public tpp::impl::VectorToKernelBase<VectorToKernel>,
 
 private:
   void constructPipeline() override {
+    pm.addNestedPass<func::FuncOp>(createBF16DotProduct());
     pm.addNestedPass<func::FuncOp>(createHoistVectorTransfers());
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     pm.addNestedPass<func::FuncOp>(createVectorContractToFMA());

--- a/lib/TPP/Transforms/CMakeLists.txt
+++ b/lib/TPP/Transforms/CMakeLists.txt
@@ -30,6 +30,7 @@ add_mlir_library(TPPTransforms
   VectorContractToOuterproduct.cpp
   HoistVectorTransfers.cpp
   VectorContractToFMA.cpp
+  VectorContractToBF16DotProduct.cpp
 
   ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/TPP

--- a/lib/TPP/Transforms/VectorContractToBF16DotProduct.cpp
+++ b/lib/TPP/Transforms/VectorContractToBF16DotProduct.cpp
@@ -1,0 +1,381 @@
+//===-VectorContractToBF16DotProduct.cpp
+//-----------------------------------------*-
+// C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements tile configuration hoisting on parallel loops.
+//
+//===----------------------------------------------------------------------===//
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
+#include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
+#include "mlir/Dialect/X86Vector/X86VectorDialect.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace tpp {
+#define GEN_PASS_DEF_BF16DOTPRODUCT
+#include "TPP/Passes.h.inc"
+} // namespace tpp
+} // namespace mlir
+
+namespace mlir {
+namespace tpp {
+
+static FailureOr<SmallVector<vector::TransferReadOp>>
+getContractOperands(vector::ContractionOp contractOp) {
+  SmallVector<vector::TransferReadOp> list;
+  for (int i = 0; i < 3; i++) {
+    auto vectorReadOp =
+        contractOp.getOperand(i).getDefiningOp<vector::TransferReadOp>();
+    if (!vectorReadOp)
+      return failure();
+    list.push_back(vectorReadOp);
+  }
+  return list;
+}
+
+static FailureOr<SmallVector<memref::SubViewOp>>
+getReadOperands(SmallVector<vector::TransferReadOp> readOps) {
+  SmallVector<memref::SubViewOp> list;
+  for (vector::TransferReadOp readOp : readOps) {
+    auto subViewOp = readOp.getOperand(0).getDefiningOp<memref::SubViewOp>();
+    if (!subViewOp)
+      return failure();
+    list.push_back(subViewOp);
+  }
+  return list;
+}
+
+static FailureOr<SmallVector<scf::ForOp>>
+getNestedLoop(vector::ContractionOp contractOp) {
+  SmallVector<scf::ForOp> list;
+  Operation *current = contractOp;
+  for (int i = 0; i < 4; i++) {
+    Operation *parent = current->getParentOfType<scf::ForOp>();
+    if (!parent)
+      return failure();
+    list.push_back(dyn_cast<scf::ForOp>(parent));
+    current = parent;
+  }
+  return list;
+}
+
+static LogicalResult checkNestedLoop(SmallVector<scf::ForOp> loops,
+                                     SmallVector<memref::SubViewOp> subviews) {
+  auto subviewOpLhsOffsets = subviews[0].getOffsets();
+  auto subviewOpRhsOffsets = subviews[1].getOffsets();
+  auto subviewOpAccOffsets = subviews[2].getOffsets();
+
+  Value ivK = loops[0].getInductionVar();
+  if (ivK != subviewOpLhsOffsets[2] || ivK != subviewOpRhsOffsets[1])
+    return failure();
+
+  Value ivReduction = loops[1].getInductionVar();
+  if (ivReduction != subviewOpLhsOffsets[0] ||
+      ivReduction != subviewOpRhsOffsets[0])
+    return failure();
+
+  Value ivN = loops[2].getInductionVar();
+  if (ivN != subviewOpAccOffsets[1] || ivN != subviewOpRhsOffsets[2])
+    return failure();
+
+  Value ivM = loops[3].getInductionVar();
+  if (ivM != subviewOpLhsOffsets[1] || ivM != subviewOpAccOffsets[0])
+    return failure();
+
+  return success();
+}
+
+struct BF16DotProductOp : OpRewritePattern<vector::ContractionOp> {
+  using OpRewritePattern<vector::ContractionOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::ContractionOp contractOp,
+                                PatternRewriter &rewriter) const override {
+
+    // Check the vector contract operation satisfies the required pattern.
+    // Check the Acc, Lhs, and Rhs of contract operation
+
+    auto operands = getContractOperands(contractOp);
+    if (failed(operands))
+      return rewriter.notifyMatchFailure(contractOp,
+                                         "Invalid operands for contract op");
+    auto readOps = *operands;
+    auto vectorReadOpAcc = readOps[2];
+    auto vectorReadOpLhs = readOps[0];
+    auto vectorReadOpRhs = readOps[1];
+
+    // Check whether the operand of vector transfer read is a subview
+    auto readOpSubviews = getReadOperands(readOps);
+    if (failed(readOpSubviews))
+      return rewriter.notifyMatchFailure(
+          contractOp, "Vector read op operands are not a subview");
+
+    auto subviews = *readOpSubviews;
+    auto subviewOpAcc = subviews[2];
+
+    // Check the operation type MatMul, B-MatMul, or BR-MatMul (FP32/BF16)
+    SmallVector<vector::IteratorType> contractIteratorTypes =
+        contractOp.getIteratorTypesArray();
+    int reductionCount =
+        std::count(contractIteratorTypes.begin(), contractIteratorTypes.end(),
+                   vector::IteratorType::reduction);
+
+    if (reductionCount == 0)
+      return rewriter.notifyMatchFailure(contractOp,
+                                         "Matmul operation not supported yet");
+
+    if (reductionCount == 1)
+      return rewriter.notifyMatchFailure(
+          contractOp, "Batch matmul operation not supported yet");
+
+    if (reductionCount == 2)
+      return rewriter.notifyMatchFailure(
+          contractOp, "Batch reduce matmul operation without vnni layout");
+
+    if (reductionCount > 3)
+      return rewriter.notifyMatchFailure(
+          contractOp, "The vector contract operation is not a gemm");
+
+    auto lhsType = dyn_cast<ShapedType>(vectorReadOpLhs.getType());
+    auto rhsType = dyn_cast<ShapedType>(vectorReadOpRhs.getType());
+    auto accType = dyn_cast<ShapedType>(vectorReadOpAcc.getType());
+
+    if (reductionCount == 3 &&
+        (lhsType.getRank() != 4 || rhsType.getRank() != 4))
+      return rewriter.notifyMatchFailure(
+          contractOp,
+          "Invalid rank for batch reduce operation with vnni layout");
+
+    int64_t M = accType.getDimSize(0);
+    int64_t N = accType.getDimSize(1);
+    int64_t K = lhsType.getDimSize(lhsType.getRank() - 2);
+    int64_t vnni = lhsType.getDimSize(lhsType.getRank() - 1);
+
+    // K tile should be equal to vnni layout
+    if (K != (vnni / 2))
+      return rewriter.notifyMatchFailure(
+          contractOp, "K tile size should be equal to VNNI layout");
+
+    if (N != 32)
+      return rewriter.notifyMatchFailure(
+          contractOp,
+          "N tile size should be equal to 32 to ensure avx512bf16 dp");
+
+    if (vnni != 2)
+      return rewriter.notifyMatchFailure(
+          contractOp, "Only VNNI layout=2 is supported, now");
+
+    auto loops = getNestedLoop(contractOp);
+    if (failed(loops))
+      return rewriter.notifyMatchFailure(
+          contractOp, "Invalid loop nest in contract pattern");
+
+    auto checkLoops = checkNestedLoop(*loops, subviews);
+    if (failed(checkLoops))
+      return rewriter.notifyMatchFailure(
+          contractOp, "Loops doesn't match the iv in subviews");
+
+    auto nestedLoops = *loops;
+    auto kForOp = nestedLoops[0];
+    auto reductionForOp = nestedLoops[1];
+
+    rewriter.setInsertionPoint(reductionForOp);
+    Value c0 =
+        rewriter.create<arith::ConstantIndexOp>(reductionForOp.getLoc(), 0);
+    auto elementType =
+        (cast<MemRefType>(subviewOpAcc.getType())).getElementType();
+
+    // Creating further subviews from the C matrix subview
+    llvm::SmallVector<OpFoldResult> sizes = {rewriter.getIndexAttr(K),
+                                             rewriter.getIndexAttr(N)};
+    llvm::SmallVector<OpFoldResult> strides = {rewriter.getIndexAttr(1),
+                                               rewriter.getIndexAttr(1)};
+    llvm::SmallVector<Value, 8> subviewCMatrix;
+    llvm::SmallVector<Value, 8> loopItrArgs;
+    for (int i = 0; i < M; i++) {
+      SmallVector<OpFoldResult> offsets = {
+          rewriter.getIndexAttr(i),
+          rewriter.getIndexAttr(0),
+      };
+      auto newSubview = rewriter.create<memref::SubViewOp>(
+          reductionForOp.getLoc(), subviewOpAcc, offsets, sizes, strides);
+      subviewCMatrix.push_back(newSubview);
+
+      // vector <16xf32> for iterargs to accumulate results in fp32
+      for (int j = 0; j < vnni; j++) {
+        Value indexOp = rewriter.create<arith::ConstantIndexOp>(
+            reductionForOp.getLoc(), j * (N / 2));
+        auto valueCRow = rewriter.create<vector::LoadOp>(
+            reductionForOp.getLoc(), VectorType::get({N / 2}, elementType),
+            newSubview, ValueRange{c0, indexOp});
+        auto bitcast_i16 = rewriter.create<vector::BitCastOp>(
+            reductionForOp.getLoc(),
+            VectorType::get({N / 2}, rewriter.getIntegerType(16)), valueCRow);
+        auto extend_i32 = rewriter.create<arith::ExtUIOp>(
+            reductionForOp.getLoc(),
+            VectorType::get({N / 2}, rewriter.getIntegerType(32)), bitcast_i16);
+        auto cst16 = rewriter.create<arith::ConstantOp>(
+            reductionForOp.getLoc(),
+            rewriter.getIntegerAttr(rewriter.getIntegerType(32), N / 2));
+        auto vectType = VectorType::get({N / 2}, rewriter.getIntegerType(32));
+        auto shiftOp = rewriter.create<arith::ShLIOp>(
+            reductionForOp.getLoc(), vectType, extend_i32,
+            rewriter.create<vector::BroadcastOp>(reductionForOp.getLoc(),
+                                                 vectType, cst16));
+        auto f32CVector = rewriter.create<vector::BitCastOp>(
+            reductionForOp.getLoc(),
+            VectorType::get({N / 2}, rewriter.getF32Type()), shiftOp);
+
+        loopItrArgs.push_back(f32CVector);
+      }
+    }
+
+    SmallVector<Value, 8> bf16DP;
+
+    // Code to re-create the reduction and k loop with iter args
+    auto newReductionForOp = rewriter.create<scf::ForOp>(
+        reductionForOp.getLoc(), reductionForOp.getLowerBound(),
+        reductionForOp.getUpperBound(), reductionForOp.getStep(), loopItrArgs,
+        [&](OpBuilder &rewriterNewReductionForOp, Location locNewReductionForOp,
+            Value ivNewReductionForOp, ValueRange iterArgsNewReductionForOp) {
+          auto newKForOp = rewriter.create<scf::ForOp>(
+              kForOp.getLoc(), kForOp.getLowerBound(), kForOp.getUpperBound(),
+              kForOp.getStep(), iterArgsNewReductionForOp,
+              [&](OpBuilder &rewriterNewKForOp, Location locNewKForOp,
+                  Value ivNewKForOp, ValueRange iterArgsNewKForOp) {
+                IRMapping mapping;
+                mapping.map(
+                    vectorReadOpLhs.getSource().getDefiningOp()->getOperand(1),
+                    ivNewReductionForOp);
+                mapping.map(
+                    vectorReadOpLhs.getSource().getDefiningOp()->getOperand(3),
+                    ivNewKForOp);
+                auto lhsClone = rewriterNewKForOp.clone(
+                    *vectorReadOpLhs.getSource().getDefiningOp(), mapping);
+
+                // Memory access for A Matrix into <32xbf16>
+                llvm::SmallVector<Value, 8> vectorA;
+
+                for (int i = 0; i < M; i++) {
+                  Value indexOp = rewriter.create<arith::ConstantIndexOp>(
+                      reductionForOp.getLoc(), i);
+                  auto valueA = rewriterNewKForOp.create<vector::LoadOp>(
+                      kForOp.getLoc(), VectorType::get({vnni}, elementType),
+                      lhsClone->getResult(0), ValueRange{c0, indexOp, c0, c0});
+                  auto bitcastValueA =
+                      rewriterNewKForOp.create<vector::BitCastOp>(
+                          kForOp.getLoc(),
+                          VectorType::get({1}, rewriterNewKForOp.getI32Type()),
+                          valueA);
+                  auto broadcastValueA =
+                      rewriterNewKForOp.create<vector::BroadcastOp>(
+                          kForOp.getLoc(),
+                          VectorType::get(16, rewriterNewKForOp.getI32Type()),
+                          bitcastValueA);
+                  auto bitcastValueA_32 =
+                      rewriterNewKForOp.create<vector::BitCastOp>(
+                          kForOp.getLoc(),
+                          VectorType::get({N}, rewriterNewKForOp.getBF16Type()),
+                          broadcastValueA);
+
+                  vectorA.push_back(bitcastValueA_32);
+                }
+
+                IRMapping rhsMapping;
+                rhsMapping.map(
+                    vectorReadOpRhs.getSource().getDefiningOp()->getOperand(1),
+                    ivNewReductionForOp);
+                rhsMapping.map(
+                    vectorReadOpRhs.getSource().getDefiningOp()->getOperand(2),
+                    ivNewKForOp);
+                auto rhsClone = rewriterNewKForOp.clone(
+                    *vectorReadOpRhs.getSource().getDefiningOp(), rhsMapping);
+
+                // Memory access for B Matrix into <32xbf16>
+                llvm::SmallVector<Value, 8> vectorB;
+                for (int i = 0, j = 0; i < vnni; i++, j = j + 16) {
+                  Value indexOp = rewriter.create<arith::ConstantIndexOp>(
+                      reductionForOp.getLoc(), j);
+                  auto valueBRow = rewriterNewKForOp.create<vector::LoadOp>(
+                      kForOp.getLoc(), VectorType::get({N}, elementType),
+                      rhsClone->getResult(0), ValueRange{c0, c0, indexOp, c0});
+                  vectorB.push_back(valueBRow);
+                }
+
+                // Code for x86vector.avx512.dot
+                mlir::VectorType dstType =
+                    mlir::VectorType::get({N / 2}, rewriter.getF32Type());
+                for (int i = 0, k = 0; i < M; i++, k = k + vnni) {
+                  for (int j = 0; j < vnni; j++) {
+                    auto dp = rewriter.create<mlir::x86vector::DotBF16Op>(
+                        kForOp.getLoc(), dstType, iterArgsNewKForOp[j + k],
+                        vectorA[i], vectorB[j]);
+                    bf16DP.push_back(dp);
+                  }
+                }
+
+                rewriterNewKForOp.create<scf::YieldOp>(locNewKForOp, bf16DP);
+              });
+
+          rewriterNewReductionForOp.create<scf::YieldOp>(
+              locNewReductionForOp, newKForOp.getResults());
+        });
+
+    // Downconvert <16xf32> to <16xbf16> and store into C Matrix
+    for (int i = 0, k = 0; i < M; i++) {
+      for (int j = 0; j < vnni; j++) {
+        Value indexOp = rewriter.create<arith::ConstantIndexOp>(
+            reductionForOp.getLoc(), j * 16);
+        auto bf16vec = rewriter.create<arith::TruncFOp>(
+            reductionForOp.getLoc(),
+            VectorType::get({16}, rewriter.getBF16Type()),
+            newReductionForOp.getResult(k));
+        rewriter.create<vector::StoreOp>(reductionForOp.getLoc(), bf16vec,
+                                         subviewCMatrix[i],
+                                         ValueRange{c0, indexOp});
+        k++;
+      }
+    }
+
+    // Delete the contract operation
+    for (auto result : contractOp->getResults()) {
+      for (auto *userOp : result.getUsers()) {
+        rewriter.eraseOp(userOp);
+      }
+    }
+    rewriter.eraseOp(contractOp);
+    return success();
+  }
+};
+
+void populateBF16DotProductPatterns(RewritePatternSet &patterns) {
+  patterns.add<BF16DotProductOp>(patterns.getContext());
+}
+
+struct BF16DotProduct : public impl::BF16DotProductBase<BF16DotProduct> {
+  using BF16DotProductBase::BF16DotProductBase;
+
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    populateBF16DotProductPatterns(patterns);
+    GreedyRewriteConfig config;
+    config.strictMode = GreedyRewriteStrictness::ExistingOps;
+    (void)applyPatternsGreedily(getOperation(), std::move(patterns), config);
+  }
+};
+} // namespace tpp
+} // namespace mlir

--- a/lib/TPP/Transforms/VectorContractToBF16DotProduct.cpp
+++ b/lib/TPP/Transforms/VectorContractToBF16DotProduct.cpp
@@ -222,7 +222,7 @@ struct BF16DotProductOp : OpRewritePattern<vector::ContractionOp> {
 
     if (reductionCount == 0)
       return rewriter.notifyMatchFailure(
-          contractOp, "Element-wise operation not supported yet");
+          contractOp, "Expected at least one reduction");
 
     if (reductionCount == 1)
       return rewriter.notifyMatchFailure(

--- a/test/BF16/Integration/vector-contract-to-bf16dp.mlir
+++ b/test/BF16/Integration/vector-contract-to-bf16dp.mlir
@@ -1,0 +1,95 @@
+// RUN: tpp-run  -e gemm_bf16_dp_random_AB --entry-point-result=void -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
+// RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=4,32,2"  --loop-invariant-code-motion --vectorization-pass --vector-contract-to-bf16dp | tpp-run  -e gemm_bf16_dp_random_AB --entry-point-result=void -print  --splat-to-random --init-type normal  -seed 123  > %t.2
+// RUN: fpcmp -r 0.001 %t.1 %t.2
+
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
+memref.global "private" constant @__constant_32x16x32x2xbf16 : memref<32x16x32x2xbf16> = dense<1.000000e+00> {alignment = 64 : i64}
+func.func @gemm_bf16_dp_random_AB(%arg0: memref<8x32x32x32xbf16>) -> memref<8x32x32x32xbf16> {
+  %cst = arith.constant 0.000000e+00 : bf16
+  %0 = memref.get_global @__constant_32x16x32x2xbf16 : memref<32x16x32x2xbf16>
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x32x32x32xbf16>
+  %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [8, 32, 32, 16, 2] : memref<8x32x32x32xbf16> into memref<8x32x32x16x2xbf16>
+  scf.forall (%arg1, %arg2) in (8, 32) {
+    %subview = memref.subview %alloc[%arg1, %arg2, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x32x32x32xbf16> to memref<32x32xbf16, strided<[32, 1], offset: ?>>
+    linalg.fill ins(%cst : bf16) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>)
+    %subview_0 = memref.subview %expand_shape[%arg1, 0, 0, 0, 0] [1, 32, 32, 16, 2] [1, 1, 1, 1, 1] : memref<8x32x32x16x2xbf16> to memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
+    linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%subview_0, %0 : memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, memref<32x16x32x2xbf16>) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
+    ^bb0(%in: bf16, %in_1: bf16, %out: bf16):
+      %1 = arith.mulf %in, %in_1 : bf16
+      %2 = arith.addf %out, %1 : bf16
+      linalg.yield %2 : bf16
+    }
+  }
+  return %alloc : memref<8x32x32x32xbf16>
+}
+
+// RUN: tpp-run -e gemm_bf16_args --entry-point-result=void -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
+// RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=8,32,2"  --loop-invariant-code-motion --vectorization-pass --vector-contract-to-bf16dp | tpp-run -e  gemm_bf16_args --entry-point-result=void -print  --splat-to-random --init-type normal  -seed 123  > %t.2
+// RUN: fpcmp -r 0.01 %t.1 %t.2
+
+#mapA = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>
+#mapB = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>
+#mapC = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
+func.func @gemm_bf16_args(%arg0: memref<8x32x32x32xbf16>, %arg1: memref<32x32x16x32x2xbf16>, %arg2: memref<8x32x32x32xbf16>) -> memref<8x32x32x32xbf16> {
+  %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [8, 32, 32, 16, 2] : memref<8x32x32x32xbf16> into memref<8x32x32x16x2xbf16>
+  scf.forall (%arg3, %arg4) in (8, 32) {
+    %subview = memref.subview %expand_shape[%arg3, 0, 0, 0, 0] [1, 32, 32, 16, 2] [1, 1, 1, 1, 1] : memref<8x32x32x16x2xbf16> to memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
+    %subview_0 = memref.subview %arg1[%arg4, 0, 0, 0, 0] [1, 32, 16, 32, 2] [1, 1, 1, 1, 1] : memref<32x32x16x32x2xbf16> to memref<32x16x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>
+    %subview_1 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x32x32x32xbf16> to memref<32x32xbf16, strided<[32, 1], offset: ?>>
+    linalg.generic {indexing_maps = [#mapA, #mapB, #mapC], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%subview, %subview_0 : memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, memref<32x16x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>) outs(%subview_1 : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
+    ^bb0(%in: bf16, %in_2: bf16, %out: bf16):
+      %0 = arith.mulf %in, %in_2 : bf16
+      %1 = arith.addf %out, %0 : bf16
+      linalg.yield %1 : bf16
+    }
+  }
+  %alloc = memref.alloc() : memref<8x32x32x32xbf16>
+  memref.copy %arg2, %alloc : memref<8x32x32x32xbf16> to memref<8x32x32x32xbf16>
+  return %alloc : memref<8x32x32x32xbf16>
+}
+
+
+
+// RUN: tpp-run -e mlp_bf16 --entry-point-result=void -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
+// RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=8,32,2"  --loop-invariant-code-motion --vectorization-pass --vector-contract-to-bf16dp | tpp-run -e  mlp_bf16 --entry-point-result=void -print  --splat-to-random --init-type normal  -seed 123  > %t.2
+// RUN: fpcmp -r 0.01 %t.1 %t.2
+
+
+#mapQ = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>
+#mapR = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>
+#mapS = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
+#mapT = affine_map<(d0, d1) -> (d1)>
+#mapU = affine_map<(d0, d1) -> (d0, d1)>
+memref.global "private" constant @__constant_32xbf16 : memref<32xbf16> = dense<1.000000e+00> {alignment = 64 : i64}
+func.func @mlp_bf16(%arg0: memref<8x32x32x32xbf16>) -> memref<8x32x32x32xbf16> {
+  %cst = arith.constant 0.000000e+00 : bf16
+  %0 = memref.get_global @__constant_32xbf16 : memref<32xbf16>
+  %1 = memref.get_global @__constant_32x16x32x2xbf16 : memref<32x16x32x2xbf16>
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x32x32x32xbf16>
+  %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [8, 32, 32, 16, 2] : memref<8x32x32x32xbf16> into memref<8x32x32x16x2xbf16>
+  scf.forall (%arg1, %arg2) in (8, 32) {
+    %subview = memref.subview %alloc[%arg1, %arg2, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x32x32x32xbf16> to memref<32x32xbf16, strided<[32, 1], offset: ?>>
+    linalg.fill ins(%cst : bf16) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>)
+    %subview_0 = memref.subview %expand_shape[%arg1, 0, 0, 0, 0] [1, 32, 32, 16, 2] [1, 1, 1, 1, 1] : memref<8x32x32x16x2xbf16> to memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
+    linalg.generic {indexing_maps = [#mapQ, #mapR, #mapS], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%subview_0, %1 : memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, memref<32x16x32x2xbf16>) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
+    ^bb0(%in: bf16, %in_1: bf16, %out: bf16):
+      %2 = arith.mulf %in, %in_1 : bf16
+      %3 = arith.addf %out, %2 : bf16
+      linalg.yield %3 : bf16
+    }
+    linalg.generic {indexing_maps = [#mapT, #mapU], iterator_types = ["parallel", "parallel"]} ins(%0 : memref<32xbf16>) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
+    ^bb0(%in: bf16, %out: bf16):
+      %2 = arith.addf %in, %out : bf16
+      linalg.yield %2 : bf16
+    }
+    linalg.generic {indexing_maps = [#mapU], iterator_types = ["parallel", "parallel"]} outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
+    ^bb0(%out: bf16):
+      %2 = arith.maximumf %out, %cst : bf16
+      linalg.yield %2 : bf16
+    }
+  }
+  return %alloc : memref<8x32x32x32xbf16>
+}
+

--- a/test/BF16/Integration/vector-contract-to-bf16dp.mlir
+++ b/test/BF16/Integration/vector-contract-to-bf16dp.mlir
@@ -2,94 +2,81 @@
 // RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=4,32,2"  --loop-invariant-code-motion --vectorization-pass --vector-contract-to-bf16dp | tpp-run  -e gemm_bf16_dp_random_AB --entry-point-result=void -print  --splat-to-random --init-type normal  -seed 123  > %t.2
 // RUN: fpcmp -r 0.001 %t.1 %t.2
 
-#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>
-#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>
-#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
-memref.global "private" constant @__constant_32x16x32x2xbf16 : memref<32x16x32x2xbf16> = dense<1.000000e+00> {alignment = 64 : i64}
-func.func @gemm_bf16_dp_random_AB(%arg0: memref<8x32x32x32xbf16>) -> memref<8x32x32x32xbf16> {
+memref.global "private" constant @__constant_2x16x32x2xbf16 : memref<2x16x32x2xbf16> = dense<1.000000e+00> {alignment = 64 : i64}
+func.func @gemm_bf16_dp_random_AB(%arg0: memref<8x2x32x32xbf16>) -> memref<8x2x32x32xbf16> {
   %cst = arith.constant 0.000000e+00 : bf16
-  %0 = memref.get_global @__constant_32x16x32x2xbf16 : memref<32x16x32x2xbf16>
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x32x32x32xbf16>
-  %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [8, 32, 32, 16, 2] : memref<8x32x32x32xbf16> into memref<8x32x32x16x2xbf16>
-  scf.forall (%arg1, %arg2) in (8, 32) {
-    %subview = memref.subview %alloc[%arg1, %arg2, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x32x32x32xbf16> to memref<32x32xbf16, strided<[32, 1], offset: ?>>
+  %0 = memref.get_global @__constant_2x16x32x2xbf16 : memref<2x16x32x2xbf16>
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x2x32x32xbf16>
+  %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [8, 2, 32, 16, 2] : memref<8x2x32x32xbf16> into memref<8x2x32x16x2xbf16>
+  scf.forall (%arg1, %arg2) in (8, 2) {
+    %subview = memref.subview %alloc[%arg1, %arg2, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x2x32x32xbf16> to memref<32x32xbf16, strided<[32, 1], offset: ?>>
     linalg.fill ins(%cst : bf16) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>)
-    %subview_0 = memref.subview %expand_shape[%arg1, 0, 0, 0, 0] [1, 32, 32, 16, 2] [1, 1, 1, 1, 1] : memref<8x32x32x16x2xbf16> to memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
-    linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%subview_0, %0 : memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, memref<32x16x32x2xbf16>) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
+    %subview_0 = memref.subview %expand_shape[%arg1, 0, 0, 0, 0] [1, 2, 32, 16, 2] [1, 1, 1, 1, 1] : memref<8x2x32x16x2xbf16> to memref<2x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
+    linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%subview_0, %0 : memref<2x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, memref<2x16x32x2xbf16>) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
     ^bb0(%in: bf16, %in_1: bf16, %out: bf16):
       %1 = arith.mulf %in, %in_1 : bf16
       %2 = arith.addf %out, %1 : bf16
       linalg.yield %2 : bf16
     }
   }
-  return %alloc : memref<8x32x32x32xbf16>
+  return %alloc : memref<8x2x32x32xbf16>
 }
+
 
 // RUN: tpp-run -e gemm_bf16_args --entry-point-result=void -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
 // RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=8,32,2"  --loop-invariant-code-motion --vectorization-pass --vector-contract-to-bf16dp | tpp-run -e  gemm_bf16_args --entry-point-result=void -print  --splat-to-random --init-type normal  -seed 123  > %t.2
 // RUN: fpcmp -r 0.01 %t.1 %t.2
 
-#mapA = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>
-#mapB = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>
-#mapC = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
-func.func @gemm_bf16_args(%arg0: memref<8x32x32x32xbf16>, %arg1: memref<32x32x16x32x2xbf16>, %arg2: memref<8x32x32x32xbf16>) -> memref<8x32x32x32xbf16> {
-  %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [8, 32, 32, 16, 2] : memref<8x32x32x32xbf16> into memref<8x32x32x16x2xbf16>
-  scf.forall (%arg3, %arg4) in (8, 32) {
-    %subview = memref.subview %expand_shape[%arg3, 0, 0, 0, 0] [1, 32, 32, 16, 2] [1, 1, 1, 1, 1] : memref<8x32x32x16x2xbf16> to memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
-    %subview_0 = memref.subview %arg1[%arg4, 0, 0, 0, 0] [1, 32, 16, 32, 2] [1, 1, 1, 1, 1] : memref<32x32x16x32x2xbf16> to memref<32x16x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>
-    %subview_1 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x32x32x32xbf16> to memref<32x32xbf16, strided<[32, 1], offset: ?>>
-    linalg.generic {indexing_maps = [#mapA, #mapB, #mapC], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%subview, %subview_0 : memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, memref<32x16x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>) outs(%subview_1 : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
+func.func @gemm_bf16_args(%arg0: memref<4x2x64x64xbf16>, %arg1: memref<2x2x32x64x2xbf16>, %arg2: memref<4x2x64x64xbf16>) -> memref<4x2x64x64xbf16> {
+  %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [4, 2, 64, 32, 2] : memref<4x2x64x64xbf16> into memref<4x2x64x32x2xbf16>
+  scf.forall (%arg3, %arg4) in (4, 2) {
+    %subview = memref.subview %expand_shape[%arg3, 0, 0, 0, 0] [1, 2, 64, 32, 2] [1, 1, 1, 1, 1] : memref<4x2x64x32x2xbf16> to memref<2x64x32x2xbf16, strided<[4096, 64, 2, 1], offset: ?>>
+    %subview_0 = memref.subview %arg1[%arg4, 0, 0, 0, 0] [1, 2, 32, 64, 2] [1, 1, 1, 1, 1] : memref<2x2x32x64x2xbf16> to memref<2x32x64x2xbf16, strided<[4096, 128, 2, 1], offset: ?>>
+    %subview_1 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 64, 64] [1, 1, 1, 1] : memref<4x2x64x64xbf16> to memref<64x64xbf16, strided<[64, 1], offset: ?>>
+    linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%subview, %subview_0 : memref<2x64x32x2xbf16, strided<[4096, 64, 2, 1], offset: ?>>, memref<2x32x64x2xbf16, strided<[4096, 128, 2, 1], offset: ?>>) outs(%subview_1 : memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
     ^bb0(%in: bf16, %in_2: bf16, %out: bf16):
       %0 = arith.mulf %in, %in_2 : bf16
       %1 = arith.addf %out, %0 : bf16
       linalg.yield %1 : bf16
     }
   }
-  %alloc = memref.alloc() : memref<8x32x32x32xbf16>
-  memref.copy %arg2, %alloc : memref<8x32x32x32xbf16> to memref<8x32x32x32xbf16>
-  return %alloc : memref<8x32x32x32xbf16>
+  %alloc = memref.alloc() : memref<4x2x64x64xbf16>
+  memref.copy %arg2, %alloc : memref<4x2x64x64xbf16> to memref<4x2x64x64xbf16>
+  return %alloc : memref<4x2x64x64xbf16>
 }
-
 
 
 // RUN: tpp-run -e mlp_bf16 --entry-point-result=void -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
 // RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=8,32,2"  --loop-invariant-code-motion --vectorization-pass --vector-contract-to-bf16dp | tpp-run -e  mlp_bf16 --entry-point-result=void -print  --splat-to-random --init-type normal  -seed 123  > %t.2
 // RUN: fpcmp -r 0.01 %t.1 %t.2
 
-
-#mapQ = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>
-#mapR = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>
-#mapS = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
-#mapT = affine_map<(d0, d1) -> (d1)>
-#mapU = affine_map<(d0, d1) -> (d0, d1)>
 memref.global "private" constant @__constant_32xbf16 : memref<32xbf16> = dense<1.000000e+00> {alignment = 64 : i64}
-func.func @mlp_bf16(%arg0: memref<8x32x32x32xbf16>) -> memref<8x32x32x32xbf16> {
+func.func @mlp_bf16(%arg0: memref<8x2x32x32xbf16>) -> memref<8x2x32x32xbf16> {
   %cst = arith.constant 0.000000e+00 : bf16
   %0 = memref.get_global @__constant_32xbf16 : memref<32xbf16>
-  %1 = memref.get_global @__constant_32x16x32x2xbf16 : memref<32x16x32x2xbf16>
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x32x32x32xbf16>
-  %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [8, 32, 32, 16, 2] : memref<8x32x32x32xbf16> into memref<8x32x32x16x2xbf16>
-  scf.forall (%arg1, %arg2) in (8, 32) {
-    %subview = memref.subview %alloc[%arg1, %arg2, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x32x32x32xbf16> to memref<32x32xbf16, strided<[32, 1], offset: ?>>
+  %1 = memref.get_global @__constant_2x16x32x2xbf16 : memref<2x16x32x2xbf16>
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x2x32x32xbf16>
+  %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [8, 2, 32, 16, 2] : memref<8x2x32x32xbf16> into memref<8x2x32x16x2xbf16>
+  scf.forall (%arg1, %arg2) in (8, 2) {
+    %subview = memref.subview %alloc[%arg1, %arg2, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x2x32x32xbf16> to memref<32x32xbf16, strided<[32, 1], offset: ?>>
     linalg.fill ins(%cst : bf16) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>)
-    %subview_0 = memref.subview %expand_shape[%arg1, 0, 0, 0, 0] [1, 32, 32, 16, 2] [1, 1, 1, 1, 1] : memref<8x32x32x16x2xbf16> to memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
-    linalg.generic {indexing_maps = [#mapQ, #mapR, #mapS], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%subview_0, %1 : memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, memref<32x16x32x2xbf16>) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
+    %subview_0 = memref.subview %expand_shape[%arg1, 0, 0, 0, 0] [1, 2, 32, 16, 2] [1, 1, 1, 1, 1] : memref<8x2x32x16x2xbf16> to memref<2x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
+    linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%subview_0, %1 : memref<2x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, memref<2x16x32x2xbf16>) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
     ^bb0(%in: bf16, %in_1: bf16, %out: bf16):
       %2 = arith.mulf %in, %in_1 : bf16
       %3 = arith.addf %out, %2 : bf16
       linalg.yield %3 : bf16
     }
-    linalg.generic {indexing_maps = [#mapT, #mapU], iterator_types = ["parallel", "parallel"]} ins(%0 : memref<32xbf16>) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
+    linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0 : memref<32xbf16>) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
     ^bb0(%in: bf16, %out: bf16):
       %2 = arith.addf %in, %out : bf16
       linalg.yield %2 : bf16
     }
-    linalg.generic {indexing_maps = [#mapU], iterator_types = ["parallel", "parallel"]} outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
+    linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
     ^bb0(%out: bf16):
       %2 = arith.maximumf %out, %cst : bf16
       linalg.yield %2 : bf16
     }
   }
-  return %alloc : memref<8x32x32x32xbf16>
+  return %alloc : memref<8x2x32x32xbf16>
 }
-

--- a/test/Passes/pass-vector-contract-to-bf16dp.mlir
+++ b/test/Passes/pass-vector-contract-to-bf16dp.mlir
@@ -1,0 +1,177 @@
+// RUN: tpp-opt %s --vector-contract-to-bf16dp --split-input-file  | FileCheck -check-prefix=CONF1 %s
+// RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=2,32,2" --loop-invariant-code-motion --vectorization-pass --vector-contract-to-bf16dp --split-input-file  | FileCheck -check-prefix=CONF2 %s
+// RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=4,32,2" --loop-invariant-code-motion --vectorization-pass --vector-contract-to-bf16dp --split-input-file  | FileCheck -check-prefix=CONF3 %s
+// RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=2,16,2" --loop-invariant-code-motion --vectorization-pass --vector-contract-to-bf16dp --split-input-file  | FileCheck -check-prefix=CONF4 %s
+// RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=2,32,4" --loop-invariant-code-motion --vectorization-pass --vector-contract-to-bf16dp --split-input-file  | FileCheck -check-prefix=CONF5 %s
+
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3, d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d1, d2)>
+module {
+  memref.global "private" constant @__constant_32x16x32x2xbf16 : memref<32x16x32x2xbf16> = dense<1.000000e+00> {alignment = 64 : i64}
+  func.func @gemm_lower_to_bf16dp(%arg0: memref<8x32x32x32xbf16>) -> memref<8x32x32x32xbf16> {
+    %cst = arith.constant 0.000000e+00 : bf16
+    %cst_0 = arith.constant dense<0.000000e+00> : vector<32x32xbf16>
+    %c16 = arith.constant 16 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %c0 = arith.constant 0 : index
+    %0 = memref.get_global @__constant_32x16x32x2xbf16 : memref<32x16x32x2xbf16>
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x32x32x32xbf16>
+    %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [8, 32, 32, 16, 2] : memref<8x32x32x32xbf16> into memref<8x32x32x16x2xbf16>
+    scf.forall (%arg1, %arg2) in (8, 32) {
+      %subview = memref.subview %alloc[%arg1, %arg2, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x32x32x32xbf16> to memref<32x32xbf16, strided<[32, 1], offset: ?>>
+      vector.transfer_write %cst_0, %subview[%c0, %c0] {in_bounds = [true, true]} : vector<32x32xbf16>, memref<32x32xbf16, strided<[32, 1], offset: ?>>
+      %subview_1 = memref.subview %expand_shape[%arg1, 0, 0, 0, 0] [1, 32, 32, 16, 2] [1, 1, 1, 1, 1] : memref<8x32x32x16x2xbf16> to memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
+      scf.for %arg3 = %c0 to %c32 step %c1 {
+        scf.for %arg4 = %c0 to %c32 step %c32 {
+          %subview_2 = memref.subview %subview[%arg3, %arg4] [1, 32] [1, 1] : memref<32x32xbf16, strided<[32, 1], offset: ?>> to memref<1x32xbf16, strided<[32, 1], offset: ?>>
+          scf.for %arg5 = %c0 to %c32 step %c1 {
+            scf.for %arg6 = %c0 to %c16 step %c1 {
+              %subview_3 = memref.subview %subview_1[%arg5, %arg3, %arg6, 0] [1, 1, 1, 2] [1, 1, 1, 1] : memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>> to memref<1x1x1x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
+              %subview_4 = memref.subview %0[%arg5, %arg6, %arg4, 0] [1, 1, 32, 2] [1, 1, 1, 1] : memref<32x16x32x2xbf16> to memref<1x1x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>
+              %1 = vector.transfer_read %subview_3[%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x1x1x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, vector<1x1x1x2xbf16>
+              %2 = vector.transfer_read %subview_4[%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x1x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>, vector<1x1x32x2xbf16>
+              %3 = vector.transfer_read %subview_2[%c0, %c0], %cst {in_bounds = [true, true]} : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<1x32xbf16>
+              %4 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["reduction", "parallel", "parallel", "reduction", "reduction"], kind = #vector.kind<add>} %1, %2, %3 : vector<1x1x1x2xbf16>, vector<1x1x32x2xbf16> into vector<1x32xbf16>
+              vector.transfer_write %4, %subview_2[%c0, %c0] {in_bounds = [true, true]} : vector<1x32xbf16>, memref<1x32xbf16, strided<[32, 1], offset: ?>>
+            }
+          }
+        }
+      }
+    }
+    return %alloc : memref<8x32x32x32xbf16>
+  }
+}
+
+// CONF1-LABEL:   memref.global "private" constant @__constant_32x16x32x2xbf16 : memref<32x16x32x2xbf16> = dense<1.000000e+00> {alignment = 64 : i64}
+// CONF1-LABEL:   func.func @gemm_lower_to_bf16dp(
+// CONF1-SAME:                     %[[VAL_0:.*]]: memref<8x32x32x32xbf16>) -> memref<8x32x32x32xbf16> {
+// CONF1:           %[[VAL_1:.*]] = arith.constant 16 : i32
+// CONF1:           %[[VAL_2:.*]] = arith.constant dense<0.000000e+00> : vector<32x32xbf16>
+// CONF1:           %[[VAL_3:.*]] = arith.constant 16 : index
+// CONF1:           %[[VAL_4:.*]] = arith.constant 1 : index
+// CONF1:           %[[VAL_5:.*]] = arith.constant 32 : index
+// CONF1:           %[[VAL_6:.*]] = arith.constant 0 : index
+// CONF1:           %[[VAL_7:.*]] = memref.get_global @__constant_32x16x32x2xbf16 : memref<32x16x32x2xbf16>
+// CONF1:           %[[VAL_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<8x32x32x32xbf16>
+// CONF1:           %[[VAL_9:.*]] = memref.expand_shape %[[VAL_0]] {{\[\[}}0], [1], [2], [3, 4]] output_shape [8, 32, 32, 16, 2] : memref<8x32x32x32xbf16> into memref<8x32x32x16x2xbf16>
+// CONF1:           scf.forall (%[[VAL_10:.*]], %[[VAL_11:.*]]) in (8, 32) {
+// CONF1:             %[[VAL_12:.*]] = memref.subview %[[VAL_8]]{{\[}}%[[VAL_10]], %[[VAL_11]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x32x32x32xbf16> to memref<32x32xbf16, strided<[32, 1], offset: ?>>
+// CONF1:             vector.transfer_write %[[VAL_2]], %[[VAL_12]]{{\[}}%[[VAL_6]], %[[VAL_6]]] {in_bounds = [true, true]} : vector<32x32xbf16>, memref<32x32xbf16, strided<[32, 1], offset: ?>>
+// CONF1:             %[[VAL_13:.*]] = memref.subview %[[VAL_9]]{{\[}}%[[VAL_10]], 0, 0, 0, 0] [1, 32, 32, 16, 2] [1, 1, 1, 1, 1] : memref<8x32x32x16x2xbf16> to memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
+// CONF1:             scf.for %[[VAL_14:.*]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_4]] {
+// CONF1:               scf.for %[[VAL_15:.*]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_5]] {
+// CONF1:                 %[[VAL_16:.*]] = memref.subview %[[VAL_12]]{{\[}}%[[VAL_14]], %[[VAL_15]]] [1, 32] [1, 1] : memref<32x32xbf16, strided<[32, 1], offset: ?>> to memref<1x32xbf16, strided<[32, 1], offset: ?>>
+// CONF1:                 %[[VAL_17:.*]] = memref.subview %[[VAL_16]][0, 0] [1, 32] [1, 1] : memref<1x32xbf16, strided<[32, 1], offset: ?>> to memref<1x32xbf16, strided<[32, 1], offset: ?>>
+// CONF1:                 %[[VAL_18:.*]] = vector.load %[[VAL_17]]{{\[}}%[[VAL_6]], %[[VAL_6]]] : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<16xbf16>
+// CONF1:                 %[[VAL_19:.*]] = vector.bitcast %[[VAL_18]] : vector<16xbf16> to vector<16xi16>
+// CONF1:                 %[[VAL_20:.*]] = arith.extui %[[VAL_19]] : vector<16xi16> to vector<16xi32>
+// CONF1:                 %[[VAL_21:.*]] = vector.broadcast %[[VAL_1]] : i32 to vector<16xi32>
+// CONF1:                 %[[VAL_22:.*]] = arith.shli %[[VAL_20]], %[[VAL_21]] : vector<16xi32>
+// CONF1:                 %[[VAL_23:.*]] = vector.bitcast %[[VAL_22]] : vector<16xi32> to vector<16xf32>
+// CONF1:                 %[[VAL_24:.*]] = vector.load %[[VAL_17]]{{\[}}%[[VAL_6]], %[[VAL_3]]] : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<16xbf16>
+// CONF1:                 %[[VAL_25:.*]] = vector.bitcast %[[VAL_24]] : vector<16xbf16> to vector<16xi16>
+// CONF1:                 %[[VAL_26:.*]] = arith.extui %[[VAL_25]] : vector<16xi16> to vector<16xi32>
+// CONF1:                 %[[VAL_27:.*]] = vector.broadcast %[[VAL_1]] : i32 to vector<16xi32>
+// CONF1:                 %[[VAL_28:.*]] = arith.shli %[[VAL_26]], %[[VAL_27]] : vector<16xi32>
+// CONF1:                 %[[VAL_29:.*]] = vector.bitcast %[[VAL_28]] : vector<16xi32> to vector<16xf32>
+// CONF1:                 %[[VAL_30:.*]]:2 = scf.for %[[VAL_31:.*]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_4]] iter_args(%[[VAL_32:.*]] = %[[VAL_23]], %[[VAL_33:.*]] = %[[VAL_29]]) -> (vector<16xf32>, vector<16xf32>) {
+// CONF1:                   %[[VAL_34:.*]]:2 = scf.for %[[VAL_35:.*]] = %[[VAL_6]] to %[[VAL_3]] step %[[VAL_4]] iter_args(%[[VAL_36:.*]] = %[[VAL_32]], %[[VAL_37:.*]] = %[[VAL_33]]) -> (vector<16xf32>, vector<16xf32>) {
+// CONF1:                     %[[VAL_38:.*]] = memref.subview %[[VAL_13]]{{\[}}%[[VAL_31]], %[[VAL_14]], %[[VAL_35]], 0] [1, 1, 1, 2] [1, 1, 1, 1] : memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>> to memref<1x1x1x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
+// CONF1:                     %[[VAL_39:.*]] = vector.load %[[VAL_38]]{{\[}}%[[VAL_6]], %[[VAL_6]], %[[VAL_6]], %[[VAL_6]]] : memref<1x1x1x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, vector<2xbf16>
+// CONF1:                     %[[VAL_40:.*]] = vector.bitcast %[[VAL_39]] : vector<2xbf16> to vector<1xi32>
+// CONF1:                     %[[VAL_41:.*]] = vector.broadcast %[[VAL_40]] : vector<1xi32> to vector<16xi32>
+// CONF1:                     %[[VAL_42:.*]] = vector.bitcast %[[VAL_41]] : vector<16xi32> to vector<32xbf16>
+// CONF1:                     %[[VAL_43:.*]] = memref.subview %[[VAL_7]]{{\[}}%[[VAL_31]], %[[VAL_35]], %[[VAL_15]], 0] [1, 1, 32, 2] [1, 1, 1, 1] : memref<32x16x32x2xbf16> to memref<1x1x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>
+// CONF1:                     %[[VAL_44:.*]] = vector.load %[[VAL_43]]{{\[}}%[[VAL_6]], %[[VAL_6]], %[[VAL_6]], %[[VAL_6]]] : memref<1x1x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>, vector<32xbf16>
+// CONF1:                     %[[VAL_45:.*]] = vector.load %[[VAL_43]]{{\[}}%[[VAL_6]], %[[VAL_6]], %[[VAL_3]], %[[VAL_6]]] : memref<1x1x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>, vector<32xbf16>
+// CONF1:                     %[[VAL_46:.*]] = x86vector.avx512.dot %[[VAL_36]], %[[VAL_42]], %[[VAL_44]] : vector<32xbf16> -> vector<16xf32>
+// CONF1:                     %[[VAL_47:.*]] = x86vector.avx512.dot %[[VAL_37]], %[[VAL_42]], %[[VAL_45]] : vector<32xbf16> -> vector<16xf32>
+// CONF1:                     scf.yield %[[VAL_46]], %[[VAL_47]] : vector<16xf32>, vector<16xf32>
+// CONF1:                   }
+// CONF1:                   scf.yield %[[VAL_48:.*]]#0, %[[VAL_48]]#1 : vector<16xf32>, vector<16xf32>
+// CONF1:                 }
+// CONF1:                 %[[VAL_49:.*]] = arith.truncf %[[VAL_50:.*]]#0 : vector<16xf32> to vector<16xbf16>
+// CONF1:                 vector.store %[[VAL_49]], %[[VAL_17]]{{\[}}%[[VAL_6]], %[[VAL_6]]] : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<16xbf16>
+// CONF1:                 %[[VAL_51:.*]] = arith.truncf %[[VAL_50]]#1 : vector<16xf32> to vector<16xbf16>
+// CONF1:                 vector.store %[[VAL_51]], %[[VAL_17]]{{\[}}%[[VAL_6]], %[[VAL_3]]] : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<16xbf16>
+// CONF1:               }
+// CONF1:             }
+// CONF1:           }
+// CONF1:           return %[[VAL_8]] : memref<8x32x32x32xbf16>
+// CONF1:         }
+
+
+// -----
+
+
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
+module {
+  memref.global "private" constant @__constant_16x32x64x2xbf16 : memref<16x32x64x2xbf16> = dense<1.000000e+00> {alignment = 64 : i64}
+  func.func @gemm_64_tiles_testing_different_cases(%arg0: memref<4x16x64x64xbf16>) -> memref<4x16x64x64xbf16> {
+    %cst = arith.constant 0.000000e+00 : bf16
+    %0 = memref.get_global @__constant_16x32x64x2xbf16 : memref<16x32x64x2xbf16>
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<4x16x64x64xbf16>
+    %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [4, 16, 64, 32, 2] : memref<4x16x64x64xbf16> into memref<4x16x64x32x2xbf16>
+    scf.forall (%arg1, %arg2) in (4, 16) {
+      %subview = memref.subview %alloc[%arg1, %arg2, 0, 0] [1, 1, 64, 64] [1, 1, 1, 1] : memref<4x16x64x64xbf16> to memref<64x64xbf16, strided<[64, 1], offset: ?>>
+      linalg.fill ins(%cst : bf16) outs(%subview : memref<64x64xbf16, strided<[64, 1], offset: ?>>)
+      %subview_0 = memref.subview %expand_shape[%arg1, 0, 0, 0, 0] [1, 16, 64, 32, 2] [1, 1, 1, 1, 1] : memref<4x16x64x32x2xbf16> to memref<16x64x32x2xbf16, strided<[4096, 64, 2, 1], offset: ?>>
+      linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%subview_0, %0 : memref<16x64x32x2xbf16, strided<[4096, 64, 2, 1], offset: ?>>, memref<16x32x64x2xbf16>) outs(%subview : memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
+      ^bb0(%in: bf16, %in_1: bf16, %out: bf16):
+        %1 = arith.mulf %in, %in_1 : bf16
+        %2 = arith.addf %out, %1 : bf16
+        linalg.yield %2 : bf16
+      }
+    }
+    return %alloc : memref<4x16x64x64xbf16>
+  }
+}
+
+
+// CONF2-LABEL: func.func @gemm_64_tiles_testing_different_cases
+// CONF2: x86vector.avx512.dot
+// CONF2-NEXT: x86vector.avx512.dot 
+// CONF2-NEXT: x86vector.avx512.dot
+// CONF2-NEXT: x86vector.avx512.dot
+// CONF2-NEXT: scf.yield
+
+// CONF3-LABEL: func.func @gemm_64_tiles_testing_different_cases
+// CONF3: x86vector.avx512.dot
+// CONF3-NEXT: x86vector.avx512.dot
+// CONF3-NEXT: x86vector.avx512.dot
+// CONF3-NEXT: x86vector.avx512.dot
+// CONF3-NEXT: x86vector.avx512.dot
+// CONF3-NEXT: x86vector.avx512.dot
+// CONF3-NEXT: x86vector.avx512.dot
+// CONF3-NEXT: x86vector.avx512.dot
+// CONF3-NEXT: scf.yield
+
+// CONF4-LABEL: func.func @gemm_64_tiles_testing_different_cases
+// CONF4-NOT: x86vector.avx512.dot
+
+// CONF5-LABEL: func.func @gemm_64_tiles_testing_different_cases
+// CONF5-NOT: x86vector.avx512.dot
+
+// -----
+
+module {
+  func.func @gemm_no_bf16dp_lowering(%arg0: memref<16x32x16x32xf32>, %arg1: memref<32x32x32x32xf32>, %arg2: memref<16x32x16x32xf32>) {
+    scf.forall (%arg3, %arg4) in (16, 32) {
+      %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 32, 16, 32] [1, 1, 1, 1] : memref<16x32x16x32xf32> to memref<32x16x32xf32, strided<[512, 32, 1], offset: ?>>
+      %subview_0 = memref.subview %arg1[%arg4, 0, 0, 0] [1, 32, 32, 32] [1, 1, 1, 1] : memref<32x32x32x32xf32> to memref<32x32x32xf32, strided<[1024, 32, 1], offset: ?>>
+      %subview_1 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 16, 32] [1, 1, 1, 1] : memref<16x32x16x32xf32> to memref<16x32xf32, strided<[32, 1], offset: ?>>
+      linalg.batch_reduce_matmul ins(%subview, %subview_0 : memref<32x16x32xf32, strided<[512, 32, 1], offset: ?>>, memref<32x32x32xf32, strided<[1024, 32, 1], offset: ?>>) outs(%subview_1 : memref<16x32xf32, strided<[32, 1], offset: ?>>)
+    }
+    return
+  }
+}
+
+// CONF2-LABEL: func.func @gemm_no_bf16dp_lowering
+// CONF2-NOT: x86vector.avx512.dot
+
+// CONF3-LABEL: func.func @gemm_no_bf16dp_lowering
+// CONF3-NOT: x86vector.avx512.dot

--- a/test/Passes/pass-vector-contract-to-bf16dp.mlir
+++ b/test/Passes/pass-vector-contract-to-bf16dp.mlir
@@ -1,177 +1,153 @@
 // RUN: tpp-opt %s --vector-contract-to-bf16dp --split-input-file  | FileCheck -check-prefix=CONF1 %s
-// RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=2,32,2" --loop-invariant-code-motion --vectorization-pass --vector-contract-to-bf16dp --split-input-file  | FileCheck -check-prefix=CONF2 %s
-// RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=4,32,2" --loop-invariant-code-motion --vectorization-pass --vector-contract-to-bf16dp --split-input-file  | FileCheck -check-prefix=CONF3 %s
-// RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=2,16,2" --loop-invariant-code-motion --vectorization-pass --vector-contract-to-bf16dp --split-input-file  | FileCheck -check-prefix=CONF4 %s
-// RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=2,32,4" --loop-invariant-code-motion --vectorization-pass --vector-contract-to-bf16dp --split-input-file  | FileCheck -check-prefix=CONF5 %s
+// RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=4,32,2" --loop-invariant-code-motion --vectorization-pass --vector-contract-to-bf16dp --split-input-file  | FileCheck -check-prefix=CONF2 %s
+// RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=2,16,2" --loop-invariant-code-motion --vectorization-pass --vector-contract-to-bf16dp --split-input-file  | FileCheck -check-prefix=CONF3 %s
+// RUN: tpp-opt %s --tile-brgemm-linalg="registerBlocking=2,32,4" --loop-invariant-code-motion --vectorization-pass --vector-contract-to-bf16dp --split-input-file  | FileCheck -check-prefix=CONF4 %s
 
-#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3, d4)>
-#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2, d4)>
-#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d1, d2)>
 module {
-  memref.global "private" constant @__constant_32x16x32x2xbf16 : memref<32x16x32x2xbf16> = dense<1.000000e+00> {alignment = 64 : i64}
-  func.func @gemm_lower_to_bf16dp(%arg0: memref<8x32x32x32xbf16>) -> memref<8x32x32x32xbf16> {
-    %cst = arith.constant 0.000000e+00 : bf16
-    %cst_0 = arith.constant dense<0.000000e+00> : vector<32x32xbf16>
-    %c16 = arith.constant 16 : index
-    %c1 = arith.constant 1 : index
-    %c32 = arith.constant 32 : index
-    %c0 = arith.constant 0 : index
-    %0 = memref.get_global @__constant_32x16x32x2xbf16 : memref<32x16x32x2xbf16>
-    %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x32x32x32xbf16>
-    %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [8, 32, 32, 16, 2] : memref<8x32x32x32xbf16> into memref<8x32x32x16x2xbf16>
-    scf.forall (%arg1, %arg2) in (8, 32) {
-      %subview = memref.subview %alloc[%arg1, %arg2, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x32x32x32xbf16> to memref<32x32xbf16, strided<[32, 1], offset: ?>>
-      vector.transfer_write %cst_0, %subview[%c0, %c0] {in_bounds = [true, true]} : vector<32x32xbf16>, memref<32x32xbf16, strided<[32, 1], offset: ?>>
-      %subview_1 = memref.subview %expand_shape[%arg1, 0, 0, 0, 0] [1, 32, 32, 16, 2] [1, 1, 1, 1, 1] : memref<8x32x32x16x2xbf16> to memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
-      scf.for %arg3 = %c0 to %c32 step %c1 {
-        scf.for %arg4 = %c0 to %c32 step %c32 {
-          %subview_2 = memref.subview %subview[%arg3, %arg4] [1, 32] [1, 1] : memref<32x32xbf16, strided<[32, 1], offset: ?>> to memref<1x32xbf16, strided<[32, 1], offset: ?>>
-          scf.for %arg5 = %c0 to %c32 step %c1 {
-            scf.for %arg6 = %c0 to %c16 step %c1 {
-              %subview_3 = memref.subview %subview_1[%arg5, %arg3, %arg6, 0] [1, 1, 1, 2] [1, 1, 1, 1] : memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>> to memref<1x1x1x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
-              %subview_4 = memref.subview %0[%arg5, %arg6, %arg4, 0] [1, 1, 32, 2] [1, 1, 1, 1] : memref<32x16x32x2xbf16> to memref<1x1x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>
-              %1 = vector.transfer_read %subview_3[%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x1x1x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, vector<1x1x1x2xbf16>
-              %2 = vector.transfer_read %subview_4[%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x1x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>, vector<1x1x32x2xbf16>
-              %3 = vector.transfer_read %subview_2[%c0, %c0], %cst {in_bounds = [true, true]} : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<1x32xbf16>
-              %4 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["reduction", "parallel", "parallel", "reduction", "reduction"], kind = #vector.kind<add>} %1, %2, %3 : vector<1x1x1x2xbf16>, vector<1x1x32x2xbf16> into vector<1x32xbf16>
-              vector.transfer_write %4, %subview_2[%c0, %c0] {in_bounds = [true, true]} : vector<1x32xbf16>, memref<1x32xbf16, strided<[32, 1], offset: ?>>
-            }
-          }
+ func.func @gemm_lower_to_bf16dp(%arg0: memref<32x32x16x2xbf16>, %arg1: memref<32x16x32x2xbf16>, %arg2: memref<32x32xbf16>) {
+  %cst = arith.constant 0.000000e+00 : bf16
+  %c0 = arith.constant 0 : index
+  %c32 = arith.constant 32 : index
+  %c2 = arith.constant 2 : index
+  %c1 = arith.constant 1 : index
+  %c16 = arith.constant 16 : index
+  scf.for %arg3 = %c0 to %c32 step %c2 {
+    scf.for %arg4 = %c0 to %c32 step %c32 {
+      %subview = memref.subview %arg2[%arg3, %arg4] [2, 32] [1, 1] : memref<32x32xbf16> to memref<2x32xbf16, strided<[32, 1], offset: ?>>
+      scf.for %arg5 = %c0 to %c32 step %c1 {
+        scf.for %arg6 = %c0 to %c16 step %c1 {
+          %subview_0 = memref.subview %arg0[%arg5, %arg3, %arg6, 0] [1, 2, 1, 2] [1, 1, 1, 1] : memref<32x32x16x2xbf16> to memref<1x2x1x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
+          %subview_1 = memref.subview %arg1[%arg5, %arg6, %arg4, 0] [1, 1, 32, 2] [1, 1, 1, 1] : memref<32x16x32x2xbf16> to memref<1x1x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>
+          %0 = vector.transfer_read %subview_0[%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x2x1x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, vector<1x2x1x2xbf16>
+          %1 = vector.transfer_read %subview_1[%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x1x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>, vector<1x1x32x2xbf16>
+          %2 = vector.transfer_read %subview[%c0, %c0], %cst {in_bounds = [true, true]} : memref<2x32xbf16, strided<[32, 1], offset: ?>>, vector<2x32xbf16>
+          %3 = vector.contract {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"], kind = #vector.kind<add>} %0, %1, %2 : vector<1x2x1x2xbf16>, vector<1x1x32x2xbf16> into vector<2x32xbf16>
+          vector.transfer_write %3, %subview[%c0, %c0] {in_bounds = [true, true]} : vector<2x32xbf16>, memref<2x32xbf16, strided<[32, 1], offset: ?>>
         }
       }
     }
-    return %alloc : memref<8x32x32x32xbf16>
   }
+  return
+ }
 }
 
-// CONF1-LABEL:   memref.global "private" constant @__constant_32x16x32x2xbf16 : memref<32x16x32x2xbf16> = dense<1.000000e+00> {alignment = 64 : i64}
 // CONF1-LABEL:   func.func @gemm_lower_to_bf16dp(
-// CONF1-SAME:                     %[[VAL_0:.*]]: memref<8x32x32x32xbf16>) -> memref<8x32x32x32xbf16> {
-// CONF1:           %[[VAL_1:.*]] = arith.constant 16 : i32
-// CONF1:           %[[VAL_2:.*]] = arith.constant dense<0.000000e+00> : vector<32x32xbf16>
-// CONF1:           %[[VAL_3:.*]] = arith.constant 16 : index
-// CONF1:           %[[VAL_4:.*]] = arith.constant 1 : index
+// CONF1-SAME:                     %[[VAL_0:.*]]: memref<32x32x16x2xbf16>,
+// CONF1-SAME:                     %[[VAL_1:.*]]: memref<32x16x32x2xbf16>,
+// CONF1-SAME:                     %[[VAL_2:.*]]: memref<32x32xbf16>) {
+// CONF1:           %[[VAL_3:.*]] = arith.constant 16 : i32
+// CONF1:           %[[VAL_4:.*]] = arith.constant 0 : index
 // CONF1:           %[[VAL_5:.*]] = arith.constant 32 : index
-// CONF1:           %[[VAL_6:.*]] = arith.constant 0 : index
-// CONF1:           %[[VAL_7:.*]] = memref.get_global @__constant_32x16x32x2xbf16 : memref<32x16x32x2xbf16>
-// CONF1:           %[[VAL_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<8x32x32x32xbf16>
-// CONF1:           %[[VAL_9:.*]] = memref.expand_shape %[[VAL_0]] {{\[\[}}0], [1], [2], [3, 4]] output_shape [8, 32, 32, 16, 2] : memref<8x32x32x32xbf16> into memref<8x32x32x16x2xbf16>
-// CONF1:           scf.forall (%[[VAL_10:.*]], %[[VAL_11:.*]]) in (8, 32) {
-// CONF1:             %[[VAL_12:.*]] = memref.subview %[[VAL_8]]{{\[}}%[[VAL_10]], %[[VAL_11]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x32x32x32xbf16> to memref<32x32xbf16, strided<[32, 1], offset: ?>>
-// CONF1:             vector.transfer_write %[[VAL_2]], %[[VAL_12]]{{\[}}%[[VAL_6]], %[[VAL_6]]] {in_bounds = [true, true]} : vector<32x32xbf16>, memref<32x32xbf16, strided<[32, 1], offset: ?>>
-// CONF1:             %[[VAL_13:.*]] = memref.subview %[[VAL_9]]{{\[}}%[[VAL_10]], 0, 0, 0, 0] [1, 32, 32, 16, 2] [1, 1, 1, 1, 1] : memref<8x32x32x16x2xbf16> to memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
-// CONF1:             scf.for %[[VAL_14:.*]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_4]] {
-// CONF1:               scf.for %[[VAL_15:.*]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_5]] {
-// CONF1:                 %[[VAL_16:.*]] = memref.subview %[[VAL_12]]{{\[}}%[[VAL_14]], %[[VAL_15]]] [1, 32] [1, 1] : memref<32x32xbf16, strided<[32, 1], offset: ?>> to memref<1x32xbf16, strided<[32, 1], offset: ?>>
-// CONF1:                 %[[VAL_17:.*]] = memref.subview %[[VAL_16]][0, 0] [1, 32] [1, 1] : memref<1x32xbf16, strided<[32, 1], offset: ?>> to memref<1x32xbf16, strided<[32, 1], offset: ?>>
-// CONF1:                 %[[VAL_18:.*]] = vector.load %[[VAL_17]]{{\[}}%[[VAL_6]], %[[VAL_6]]] : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<16xbf16>
-// CONF1:                 %[[VAL_19:.*]] = vector.bitcast %[[VAL_18]] : vector<16xbf16> to vector<16xi16>
-// CONF1:                 %[[VAL_20:.*]] = arith.extui %[[VAL_19]] : vector<16xi16> to vector<16xi32>
-// CONF1:                 %[[VAL_21:.*]] = vector.broadcast %[[VAL_1]] : i32 to vector<16xi32>
-// CONF1:                 %[[VAL_22:.*]] = arith.shli %[[VAL_20]], %[[VAL_21]] : vector<16xi32>
-// CONF1:                 %[[VAL_23:.*]] = vector.bitcast %[[VAL_22]] : vector<16xi32> to vector<16xf32>
-// CONF1:                 %[[VAL_24:.*]] = vector.load %[[VAL_17]]{{\[}}%[[VAL_6]], %[[VAL_3]]] : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<16xbf16>
-// CONF1:                 %[[VAL_25:.*]] = vector.bitcast %[[VAL_24]] : vector<16xbf16> to vector<16xi16>
-// CONF1:                 %[[VAL_26:.*]] = arith.extui %[[VAL_25]] : vector<16xi16> to vector<16xi32>
-// CONF1:                 %[[VAL_27:.*]] = vector.broadcast %[[VAL_1]] : i32 to vector<16xi32>
-// CONF1:                 %[[VAL_28:.*]] = arith.shli %[[VAL_26]], %[[VAL_27]] : vector<16xi32>
-// CONF1:                 %[[VAL_29:.*]] = vector.bitcast %[[VAL_28]] : vector<16xi32> to vector<16xf32>
-// CONF1:                 %[[VAL_30:.*]]:2 = scf.for %[[VAL_31:.*]] = %[[VAL_6]] to %[[VAL_5]] step %[[VAL_4]] iter_args(%[[VAL_32:.*]] = %[[VAL_23]], %[[VAL_33:.*]] = %[[VAL_29]]) -> (vector<16xf32>, vector<16xf32>) {
-// CONF1:                   %[[VAL_34:.*]]:2 = scf.for %[[VAL_35:.*]] = %[[VAL_6]] to %[[VAL_3]] step %[[VAL_4]] iter_args(%[[VAL_36:.*]] = %[[VAL_32]], %[[VAL_37:.*]] = %[[VAL_33]]) -> (vector<16xf32>, vector<16xf32>) {
-// CONF1:                     %[[VAL_38:.*]] = memref.subview %[[VAL_13]]{{\[}}%[[VAL_31]], %[[VAL_14]], %[[VAL_35]], 0] [1, 1, 1, 2] [1, 1, 1, 1] : memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>> to memref<1x1x1x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
-// CONF1:                     %[[VAL_39:.*]] = vector.load %[[VAL_38]]{{\[}}%[[VAL_6]], %[[VAL_6]], %[[VAL_6]], %[[VAL_6]]] : memref<1x1x1x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, vector<2xbf16>
-// CONF1:                     %[[VAL_40:.*]] = vector.bitcast %[[VAL_39]] : vector<2xbf16> to vector<1xi32>
-// CONF1:                     %[[VAL_41:.*]] = vector.broadcast %[[VAL_40]] : vector<1xi32> to vector<16xi32>
-// CONF1:                     %[[VAL_42:.*]] = vector.bitcast %[[VAL_41]] : vector<16xi32> to vector<32xbf16>
-// CONF1:                     %[[VAL_43:.*]] = memref.subview %[[VAL_7]]{{\[}}%[[VAL_31]], %[[VAL_35]], %[[VAL_15]], 0] [1, 1, 32, 2] [1, 1, 1, 1] : memref<32x16x32x2xbf16> to memref<1x1x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>
-// CONF1:                     %[[VAL_44:.*]] = vector.load %[[VAL_43]]{{\[}}%[[VAL_6]], %[[VAL_6]], %[[VAL_6]], %[[VAL_6]]] : memref<1x1x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>, vector<32xbf16>
-// CONF1:                     %[[VAL_45:.*]] = vector.load %[[VAL_43]]{{\[}}%[[VAL_6]], %[[VAL_6]], %[[VAL_3]], %[[VAL_6]]] : memref<1x1x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>, vector<32xbf16>
-// CONF1:                     %[[VAL_46:.*]] = x86vector.avx512.dot %[[VAL_36]], %[[VAL_42]], %[[VAL_44]] : vector<32xbf16> -> vector<16xf32>
-// CONF1:                     %[[VAL_47:.*]] = x86vector.avx512.dot %[[VAL_37]], %[[VAL_42]], %[[VAL_45]] : vector<32xbf16> -> vector<16xf32>
-// CONF1:                     scf.yield %[[VAL_46]], %[[VAL_47]] : vector<16xf32>, vector<16xf32>
-// CONF1:                   }
-// CONF1:                   scf.yield %[[VAL_48:.*]]#0, %[[VAL_48]]#1 : vector<16xf32>, vector<16xf32>
+// CONF1:           %[[VAL_6:.*]] = arith.constant 2 : index
+// CONF1:           %[[VAL_7:.*]] = arith.constant 1 : index
+// CONF1:           %[[VAL_8:.*]] = arith.constant 16 : index
+// CONF1:           scf.for %[[VAL_9:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_6]] {
+// CONF1:             scf.for %[[VAL_10:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_5]] {
+// CONF1:               %[[VAL_11:.*]] = memref.subview %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]]] [2, 32] [1, 1] : memref<32x32xbf16> to memref<2x32xbf16, strided<[32, 1], offset: ?>>
+// CONF1:               %[[VAL_12:.*]] = memref.subview %[[VAL_11]][0, 0] [1, 32] [1, 1] : memref<2x32xbf16, strided<[32, 1], offset: ?>> to memref<1x32xbf16, strided<[32, 1], offset: ?>>
+// CONF1:               %[[VAL_13:.*]] = vector.load %[[VAL_12]]{{\[}}%[[VAL_4]], %[[VAL_4]]] : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<16xbf16>
+// CONF1:               %[[VAL_14:.*]] = vector.bitcast %[[VAL_13]] : vector<16xbf16> to vector<16xi16>
+// CONF1:               %[[VAL_15:.*]] = arith.extui %[[VAL_14]] : vector<16xi16> to vector<16xi32>
+// CONF1:               %[[VAL_16:.*]] = vector.broadcast %[[VAL_3]] : i32 to vector<16xi32>
+// CONF1:               %[[VAL_17:.*]] = arith.shli %[[VAL_15]], %[[VAL_16]] : vector<16xi32>
+// CONF1:               %[[VAL_18:.*]] = vector.bitcast %[[VAL_17]] : vector<16xi32> to vector<16xf32>
+// CONF1:               %[[VAL_19:.*]] = vector.load %[[VAL_12]]{{\[}}%[[VAL_4]], %[[VAL_8]]] : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<16xbf16>
+// CONF1:               %[[VAL_20:.*]] = vector.bitcast %[[VAL_19]] : vector<16xbf16> to vector<16xi16>
+// CONF1:               %[[VAL_21:.*]] = arith.extui %[[VAL_20]] : vector<16xi16> to vector<16xi32>
+// CONF1:               %[[VAL_22:.*]] = vector.broadcast %[[VAL_3]] : i32 to vector<16xi32>
+// CONF1:               %[[VAL_23:.*]] = arith.shli %[[VAL_21]], %[[VAL_22]] : vector<16xi32>
+// CONF1:               %[[VAL_24:.*]] = vector.bitcast %[[VAL_23]] : vector<16xi32> to vector<16xf32>
+// CONF1:               %[[VAL_25:.*]] = memref.subview %[[VAL_11]][1, 0] [1, 32] [1, 1] : memref<2x32xbf16, strided<[32, 1], offset: ?>> to memref<1x32xbf16, strided<[32, 1], offset: ?>>
+// CONF1:               %[[VAL_26:.*]] = vector.load %[[VAL_25]]{{\[}}%[[VAL_4]], %[[VAL_4]]] : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<16xbf16>
+// CONF1:               %[[VAL_27:.*]] = vector.bitcast %[[VAL_26]] : vector<16xbf16> to vector<16xi16>
+// CONF1:               %[[VAL_28:.*]] = arith.extui %[[VAL_27]] : vector<16xi16> to vector<16xi32>
+// CONF1:               %[[VAL_29:.*]] = vector.broadcast %[[VAL_3]] : i32 to vector<16xi32>
+// CONF1:               %[[VAL_30:.*]] = arith.shli %[[VAL_28]], %[[VAL_29]] : vector<16xi32>
+// CONF1:               %[[VAL_31:.*]] = vector.bitcast %[[VAL_30]] : vector<16xi32> to vector<16xf32>
+// CONF1:               %[[VAL_32:.*]] = vector.load %[[VAL_25]]{{\[}}%[[VAL_4]], %[[VAL_8]]] : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<16xbf16>
+// CONF1:               %[[VAL_33:.*]] = vector.bitcast %[[VAL_32]] : vector<16xbf16> to vector<16xi16>
+// CONF1:               %[[VAL_34:.*]] = arith.extui %[[VAL_33]] : vector<16xi16> to vector<16xi32>
+// CONF1:               %[[VAL_35:.*]] = vector.broadcast %[[VAL_3]] : i32 to vector<16xi32>
+// CONF1:               %[[VAL_36:.*]] = arith.shli %[[VAL_34]], %[[VAL_35]] : vector<16xi32>
+// CONF1:               %[[VAL_37:.*]] = vector.bitcast %[[VAL_36]] : vector<16xi32> to vector<16xf32>
+// CONF1:               %[[VAL_38:.*]]:4 = scf.for %[[VAL_39:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_7]] iter_args(%[[VAL_40:.*]] = %[[VAL_18]], %[[VAL_41:.*]] = %[[VAL_24]], %[[VAL_42:.*]] = %[[VAL_31]], %[[VAL_43:.*]] = %[[VAL_37]]) -> (vector<16xf32>, vector<16xf32>, vector<16xf32>, vector<16xf32>) {
+// CONF1:                 %[[VAL_44:.*]]:4 = scf.for %[[VAL_45:.*]] = %[[VAL_4]] to %[[VAL_8]] step %[[VAL_7]] iter_args(%[[VAL_46:.*]] = %[[VAL_40]], %[[VAL_47:.*]] = %[[VAL_41]], %[[VAL_48:.*]] = %[[VAL_42]], %[[VAL_49:.*]] = %[[VAL_43]]) -> (vector<16xf32>, vector<16xf32>, vector<16xf32>, vector<16xf32>) {
+// CONF1:                   %[[VAL_50:.*]] = memref.subview %[[VAL_0]]{{\[}}%[[VAL_39]], %[[VAL_9]], %[[VAL_45]], 0] [1, 2, 1, 2] [1, 1, 1, 1] : memref<32x32x16x2xbf16> to memref<1x2x1x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
+// CONF1:                   %[[VAL_51:.*]] = vector.load %[[VAL_50]]{{\[}}%[[VAL_4]], %[[VAL_4]], %[[VAL_4]], %[[VAL_4]]] : memref<1x2x1x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, vector<2xbf16>
+// CONF1:                   %[[VAL_52:.*]] = vector.bitcast %[[VAL_51]] : vector<2xbf16> to vector<1xi32>
+// CONF1:                   %[[VAL_53:.*]] = vector.broadcast %[[VAL_52]] : vector<1xi32> to vector<16xi32>
+// CONF1:                   %[[VAL_54:.*]] = vector.bitcast %[[VAL_53]] : vector<16xi32> to vector<32xbf16>
+// CONF1:                   %[[VAL_55:.*]] = vector.load %[[VAL_50]]{{\[}}%[[VAL_4]], %[[VAL_7]], %[[VAL_4]], %[[VAL_4]]] : memref<1x2x1x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, vector<2xbf16>
+// CONF1:                   %[[VAL_56:.*]] = vector.bitcast %[[VAL_55]] : vector<2xbf16> to vector<1xi32>
+// CONF1:                   %[[VAL_57:.*]] = vector.broadcast %[[VAL_56]] : vector<1xi32> to vector<16xi32>
+// CONF1:                   %[[VAL_58:.*]] = vector.bitcast %[[VAL_57]] : vector<16xi32> to vector<32xbf16>
+// CONF1:                   %[[VAL_59:.*]] = memref.subview %[[VAL_1]]{{\[}}%[[VAL_39]], %[[VAL_45]], %[[VAL_10]], 0] [1, 1, 32, 2] [1, 1, 1, 1] : memref<32x16x32x2xbf16> to memref<1x1x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>
+// CONF1:                   %[[VAL_60:.*]] = vector.load %[[VAL_59]]{{\[}}%[[VAL_4]], %[[VAL_4]], %[[VAL_4]], %[[VAL_4]]] : memref<1x1x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>, vector<32xbf16>
+// CONF1:                   %[[VAL_61:.*]] = vector.load %[[VAL_59]]{{\[}}%[[VAL_4]], %[[VAL_4]], %[[VAL_8]], %[[VAL_4]]] : memref<1x1x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>, vector<32xbf16>
+// CONF1:                   %[[VAL_62:.*]] = x86vector.avx512.dot %[[VAL_46]], %[[VAL_54]], %[[VAL_60]] : vector<32xbf16> -> vector<16xf32>
+// CONF1:                   %[[VAL_63:.*]] = x86vector.avx512.dot %[[VAL_47]], %[[VAL_54]], %[[VAL_61]] : vector<32xbf16> -> vector<16xf32>
+// CONF1:                   %[[VAL_64:.*]] = x86vector.avx512.dot %[[VAL_48]], %[[VAL_58]], %[[VAL_60]] : vector<32xbf16> -> vector<16xf32>
+// CONF1:                   %[[VAL_65:.*]] = x86vector.avx512.dot %[[VAL_49]], %[[VAL_58]], %[[VAL_61]] : vector<32xbf16> -> vector<16xf32>
+// CONF1:                   scf.yield %[[VAL_62]], %[[VAL_63]], %[[VAL_64]], %[[VAL_65]] : vector<16xf32>, vector<16xf32>, vector<16xf32>, vector<16xf32>
 // CONF1:                 }
-// CONF1:                 %[[VAL_49:.*]] = arith.truncf %[[VAL_50:.*]]#0 : vector<16xf32> to vector<16xbf16>
-// CONF1:                 vector.store %[[VAL_49]], %[[VAL_17]]{{\[}}%[[VAL_6]], %[[VAL_6]]] : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<16xbf16>
-// CONF1:                 %[[VAL_51:.*]] = arith.truncf %[[VAL_50]]#1 : vector<16xf32> to vector<16xbf16>
-// CONF1:                 vector.store %[[VAL_51]], %[[VAL_17]]{{\[}}%[[VAL_6]], %[[VAL_3]]] : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<16xbf16>
+// CONF1:                 scf.yield %[[VAL_66:.*]]#0, %[[VAL_66]]#1, %[[VAL_66]]#2, %[[VAL_66]]#3 : vector<16xf32>, vector<16xf32>, vector<16xf32>, vector<16xf32>
 // CONF1:               }
+// CONF1:               %[[VAL_67:.*]] = arith.truncf %[[VAL_68:.*]]#0 : vector<16xf32> to vector<16xbf16>
+// CONF1:               vector.store %[[VAL_67]], %[[VAL_12]]{{\[}}%[[VAL_4]], %[[VAL_4]]] : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<16xbf16>
+// CONF1:               %[[VAL_69:.*]] = arith.truncf %[[VAL_68]]#1 : vector<16xf32> to vector<16xbf16>
+// CONF1:               vector.store %[[VAL_69]], %[[VAL_12]]{{\[}}%[[VAL_4]], %[[VAL_8]]] : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<16xbf16>
+// CONF1:               %[[VAL_70:.*]] = arith.truncf %[[VAL_68]]#2 : vector<16xf32> to vector<16xbf16>
+// CONF1:               vector.store %[[VAL_70]], %[[VAL_25]]{{\[}}%[[VAL_4]], %[[VAL_4]]] : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<16xbf16>
+// CONF1:               %[[VAL_71:.*]] = arith.truncf %[[VAL_68]]#3 : vector<16xf32> to vector<16xbf16>
+// CONF1:               vector.store %[[VAL_71]], %[[VAL_25]]{{\[}}%[[VAL_4]], %[[VAL_8]]] : memref<1x32xbf16, strided<[32, 1], offset: ?>>, vector<16xbf16>
 // CONF1:             }
 // CONF1:           }
-// CONF1:           return %[[VAL_8]] : memref<8x32x32x32xbf16>
+// CONF1:           return
 // CONF1:         }
-
 
 // -----
 
 
-#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>
-#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>
-#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
 module {
-  memref.global "private" constant @__constant_16x32x64x2xbf16 : memref<16x32x64x2xbf16> = dense<1.000000e+00> {alignment = 64 : i64}
-  func.func @gemm_64_tiles_testing_different_cases(%arg0: memref<4x16x64x64xbf16>) -> memref<4x16x64x64xbf16> {
-    %cst = arith.constant 0.000000e+00 : bf16
-    %0 = memref.get_global @__constant_16x32x64x2xbf16 : memref<16x32x64x2xbf16>
-    %alloc = memref.alloc() {alignment = 64 : i64} : memref<4x16x64x64xbf16>
-    %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [4, 16, 64, 32, 2] : memref<4x16x64x64xbf16> into memref<4x16x64x32x2xbf16>
-    scf.forall (%arg1, %arg2) in (4, 16) {
-      %subview = memref.subview %alloc[%arg1, %arg2, 0, 0] [1, 1, 64, 64] [1, 1, 1, 1] : memref<4x16x64x64xbf16> to memref<64x64xbf16, strided<[64, 1], offset: ?>>
-      linalg.fill ins(%cst : bf16) outs(%subview : memref<64x64xbf16, strided<[64, 1], offset: ?>>)
-      %subview_0 = memref.subview %expand_shape[%arg1, 0, 0, 0, 0] [1, 16, 64, 32, 2] [1, 1, 1, 1, 1] : memref<4x16x64x32x2xbf16> to memref<16x64x32x2xbf16, strided<[4096, 64, 2, 1], offset: ?>>
-      linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%subview_0, %0 : memref<16x64x32x2xbf16, strided<[4096, 64, 2, 1], offset: ?>>, memref<16x32x64x2xbf16>) outs(%subview : memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
-      ^bb0(%in: bf16, %in_1: bf16, %out: bf16):
-        %1 = arith.mulf %in, %in_1 : bf16
-        %2 = arith.addf %out, %1 : bf16
-        linalg.yield %2 : bf16
-      }
+ func.func @gemm_64_tiles_testing_different_cases(%arg0: memref<32x64x32x2xbf16>, %arg1: memref<32x32x64x2xbf16>, %arg2: memref<64x64xbf16>) {
+    linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : memref<32x64x32x2xbf16>, memref<32x32x64x2xbf16>) outs(%arg2 : memref<64x64xbf16>) {
+    ^bb0(%in: bf16, %in_2: bf16, %out: bf16):
+      %0 = arith.mulf %in, %in_2 : bf16
+      %1 = arith.addf %out, %0 : bf16
+      linalg.yield %1 : bf16
     }
-    return %alloc : memref<4x16x64x64xbf16>
-  }
+  return
+ }
 }
-
 
 // CONF2-LABEL: func.func @gemm_64_tiles_testing_different_cases
 // CONF2: x86vector.avx512.dot
-// CONF2-NEXT: x86vector.avx512.dot 
+// CONF2-NEXT: x86vector.avx512.dot
+// CONF2-NEXT: x86vector.avx512.dot
+// CONF2-NEXT: x86vector.avx512.dot
+// CONF2-NEXT: x86vector.avx512.dot
+// CONF2-NEXT: x86vector.avx512.dot
 // CONF2-NEXT: x86vector.avx512.dot
 // CONF2-NEXT: x86vector.avx512.dot
 // CONF2-NEXT: scf.yield
 
 // CONF3-LABEL: func.func @gemm_64_tiles_testing_different_cases
-// CONF3: x86vector.avx512.dot
-// CONF3-NEXT: x86vector.avx512.dot
-// CONF3-NEXT: x86vector.avx512.dot
-// CONF3-NEXT: x86vector.avx512.dot
-// CONF3-NEXT: x86vector.avx512.dot
-// CONF3-NEXT: x86vector.avx512.dot
-// CONF3-NEXT: x86vector.avx512.dot
-// CONF3-NEXT: x86vector.avx512.dot
-// CONF3-NEXT: scf.yield
+// CONF3-NOT: x86vector.avx512.dot
 
 // CONF4-LABEL: func.func @gemm_64_tiles_testing_different_cases
 // CONF4-NOT: x86vector.avx512.dot
 
-// CONF5-LABEL: func.func @gemm_64_tiles_testing_different_cases
-// CONF5-NOT: x86vector.avx512.dot
-
 // -----
 
 module {
-  func.func @gemm_no_bf16dp_lowering(%arg0: memref<16x32x16x32xf32>, %arg1: memref<32x32x32x32xf32>, %arg2: memref<16x32x16x32xf32>) {
-    scf.forall (%arg3, %arg4) in (16, 32) {
-      %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 32, 16, 32] [1, 1, 1, 1] : memref<16x32x16x32xf32> to memref<32x16x32xf32, strided<[512, 32, 1], offset: ?>>
-      %subview_0 = memref.subview %arg1[%arg4, 0, 0, 0] [1, 32, 32, 32] [1, 1, 1, 1] : memref<32x32x32x32xf32> to memref<32x32x32xf32, strided<[1024, 32, 1], offset: ?>>
-      %subview_1 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 16, 32] [1, 1, 1, 1] : memref<16x32x16x32xf32> to memref<16x32xf32, strided<[32, 1], offset: ?>>
-      linalg.batch_reduce_matmul ins(%subview, %subview_0 : memref<32x16x32xf32, strided<[512, 32, 1], offset: ?>>, memref<32x32x32xf32, strided<[1024, 32, 1], offset: ?>>) outs(%subview_1 : memref<16x32xf32, strided<[32, 1], offset: ?>>)
-    }
+  func.func @gemm_no_bf16dp_lowering(%arg0: memref<32x16x32xf32>, %arg1: memref<32x32x32xf32>, %arg2: memref<16x32xf32>) {
+      linalg.batch_reduce_matmul ins(%arg0, %arg1 : memref<32x16x32xf32>, memref<32x32x32xf32>) outs(%arg2 : memref<16x32xf32>)
     return
   }
 }
 
-// CONF2-LABEL: func.func @gemm_no_bf16dp_lowering
-// CONF2-NOT: x86vector.avx512.dot
-
 // CONF3-LABEL: func.func @gemm_no_bf16dp_lowering
 // CONF3-NOT: x86vector.avx512.dot
+
+// CONF4-LABEL: func.func @gemm_no_bf16dp_lowering
+// CONF4-NOT: x86vector.avx512.dot


### PR DESCRIPTION
To support lowering of `vector.contract` to `DotBF16Op` for gemm/mlp benchmarks with `bf16` type and `vnni=2` layout.