### PR TITLE
Benchmark files for avx512bf16 dot-product

### DIFF
--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -90,7 +90,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=8,32,1'" ],
-      "extensions": ["avx512_bf16"]
+      "extensions": ["avx512.*"]
     },
     "mlp_fp32_mlir_vector_avx2": {
       "type": "IR-GEN",

--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -40,21 +40,21 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=8,32,1 '" ],
+      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=8,32,1'" ],
       "extensions": ["avx512.*"]
     },
     "gemm_fp32_mlir_vector_avx2": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=4,16,1 '" ],
+      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=4,16,1'" ],
       "extensions": ["avx2"]
     },
     "gemm_fp32_mlir_vector_sve": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=4,32,1 '" ],
+      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=4,32,1'" ],
       "extensions": ["asimd"]
     },
     "gemm_bf16_dp2_mlir": {
@@ -68,7 +68,7 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2 '" ],
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "avx512.*" ]
     },
     "gemm_bf16_dp4_mlir": {
@@ -89,21 +89,21 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=8,32,1 '" ],
+      "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=8,32,1'" ],
       "extensions": ["avx512.*"]
     },
     "mlp_fp32_mlir_vector_avx2": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=4,16,1 '" ],
+      "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=4,16,1'" ],
       "extensions": ["avx2" ]
     },
     "mlp_fp32_mlir_vector_sve": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=4,32,1 '" ],
+      "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=4,32,1'" ],
       "extensions": ["asimd"]
     },
     "mlp_bf16_dp2_mlir": {
@@ -141,7 +141,7 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,1 '" ],
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,1'" ],
       "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_args_mlir": {
@@ -200,7 +200,7 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args='--def-parallel  --vector-to-kernels --registerBlocking=8,32,1 '" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel  --vector-to-kernels --registerBlocking=8,32,1'" ],
       "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_args_mlir": {
@@ -214,7 +214,7 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args=' --def-parallel  --vector-to-kernels --registerBlocking=8,32,1 '" ],
+      "flags": [ "-n", "100", "-run-args=' --def-parallel  --vector-to-kernels --registerBlocking=8,32,1'" ],
       "extensions": [ "avx512.*" ]
     },
     "bf16_3x1024_const_mlir": {

--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -69,7 +69,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "avx512.*" ]
+      "extensions": [ "avx512_bf16" ]
     },
     "gemm_bf16_dp4_mlir": {
       "type": "IR-GEN",
@@ -90,7 +90,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=8,32,1'" ],
-      "extensions": ["avx512.*"]
+      "extensions": ["avx512_bf16"]
     },
     "mlp_fp32_mlir_vector_avx2": {
       "type": "IR-GEN",
@@ -118,7 +118,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "avx512.*" ]
+      "extensions": [ "avx512_bf16" ]
     },
     "mlp_bf16_dp4_mlir": {
       "type": "IR-GEN",
@@ -170,7 +170,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'"],
-      "extensions": [ "avx512.*" ]
+      "extensions": [ "avx512_bf16" ]
     },
     "bf16_3x1024_args_mlir": {
       "type": "IR-GEN",
@@ -184,7 +184,7 @@
       "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'"],
-      "extensions": [ "avx512.*" ]
+      "extensions": [ "avx512_bf16" ]
     }
   }},
   {
@@ -229,7 +229,7 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'"],
-      "extensions": [ "avx512.*" ]
+      "extensions": [ "avx512_bf16" ]
     },
     "bf16_3x1024_args_mlir": {
       "type": "IR-GEN",
@@ -243,7 +243,7 @@
       "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'"],
-      "extensions": [ "avx512.*" ]
+      "extensions": [ "avx512_bf16" ]
     }
   }}
 ]

--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -64,6 +64,13 @@
       "flags": [ "-n", "100" ],
       "extensions": [ "avx2" ]
     },
+    "gemm_bf16_dp2_mlir_vector_kernel_avx512bf16": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": {},
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2 '" ],
+      "extensions": [ "avx512.*" ]
+    },
     "gemm_bf16_dp4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
@@ -106,6 +113,13 @@
       "flags": [ "-n", "100" ],
       "extensions": [ "avx2" ]
     },
+    "mlp_bf16_dp2_mlir_vector_kernel_avx512bf16": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": {},
+      "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --registerBlocking=8,32,2'" ],
+      "extensions": [ "avx512.*" ]
+    },
     "mlp_bf16_dp4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
@@ -141,7 +155,7 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,1 '" ],
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,1'" ],
       "extensions": [ "avx512.*" ]
     },
     "bf16_3x1024_const_mlir": {
@@ -151,12 +165,26 @@
       "flags": [ "-n", "100"],
       "extensions": [ "(avx2|asimd)" ]
     },
+    "bf16_3x1024_const_mlir_vector_kernel_avx512bf16": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": {},
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'"],
+      "extensions": [ "avx512.*" ]
+    },
     "bf16_3x1024_args_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100"],
       "extensions": [ "(avx2|asimd)" ]
+    },
+    "bf16_3x1024_args_mlir_vector_kernel_avx512bf16": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": {},
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'"],
+      "extensions": [ "avx512.*" ]
     }
   }},
   {
@@ -196,12 +224,26 @@
       "flags": [ "-n", "100"],
       "extensions": [ "(avx2|asimd)" ]
     },
+    "bf16_3x1024_const_mlir_vector_kernel_avx512bf16": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": {},
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'"],
+      "extensions": [ "avx512.*" ]
+    },
     "bf16_3x1024_args_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100"],
       "extensions": [ "(avx2|asimd)" ]
+    },
+    "bf16_3x1024_args_mlir_vector_kernel_avx512bf16": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": {},
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'"],
+      "extensions": [ "avx512.*" ]
     }
   }}
 ]

--- a/benchmarks/config/omp/mlir-bf16.json
+++ b/benchmarks/config/omp/mlir-bf16.json
@@ -31,6 +31,37 @@
     }
   }},
   {
+  "gemm_bf16_dp2_mlir_vector_kernel_avx512bf16": {
+    "bf16_dp2_3x1024_omp_2_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --registerBlocking=8,32,2'" ],
+      "extensions": [ "(avx512.*)" ]
+    },
+    "bf16_dp2_3x1024_omp_4_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --registerBlocking=8,32,2'" ],
+      "extensions": [ "(avx512.*)" ]
+    },
+    "bf16_dp2_3x1024_omp_8_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --registerBlocking=8,32,2'" ],
+      "extensions": [ "(avx512.*)" ]
+    },
+    "bf16_dp2_3x1024_omp_16_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --registerBlocking=8,32,2'" ],
+      "extensions": [ "(avx512.*)" ]
+    }
+  }},
+  {
   "mlp_bf16_dp2_mlir": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
@@ -58,6 +89,37 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
+      "extensions": [ "(avx2)" ]
+    }
+  }},
+  {
+  "mlp_bf16_dp2_mlir_vector_kernel_avx512bf16": {
+    "bf16_dp2_3x1024_omp_2_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --registerBlocking=8,32,2'" ],
+      "extensions": [ "(avx2)" ]
+    },
+    "bf16_dp2_3x1024_omp_4_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --registerBlocking=8,32,2'" ],
+      "extensions": [ "(avx2)" ]
+    },
+    "bf16_dp2_3x1024_omp_8_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --registerBlocking=8,32,2'" ],
+      "extensions": [ "(avx2)" ]
+    },
+    "bf16_dp2_3x1024_omp_16_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --registerBlocking=8,32,2'" ],
       "extensions": [ "(avx2)" ]
     }
   }},

--- a/benchmarks/config/omp/mlir-bf16.json
+++ b/benchmarks/config/omp/mlir-bf16.json
@@ -36,28 +36,28 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --registerBlocking=8,32,2'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "(avx512.*)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --registerBlocking=8,32,2'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "(avx512.*)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --registerBlocking=8,32,2'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "(avx512.*)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --registerBlocking=8,32,2'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "(avx512.*)" ]
     }
   }},
@@ -98,28 +98,28 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --registerBlocking=8,32,2'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --registerBlocking=8,32,2'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --registerBlocking=8,32,2'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --registerBlocking=8,32,2'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "(avx2)" ]
     }
   }},

--- a/benchmarks/config/omp/mlir-bf16.json
+++ b/benchmarks/config/omp/mlir-bf16.json
@@ -37,28 +37,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "(avx512.*)" ]
+      "extensions": [ "avx512_bf16" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "(avx512.*)" ]
+      "extensions": [ "avx512_bf16" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "(avx512.*)" ]
+      "extensions": [ "avx512_bf16" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "(avx512.*)" ]
+      "extensions": [ "avx512_bf16" ]
     }
   }},
   {
@@ -99,28 +99,28 @@
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512_bf16" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512_bf16" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512_bf16" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "(avx2)" ]
+      "extensions": [ "avx512_bf16" ]
     }
   }},
   {


### PR DESCRIPTION
Adding  `json` files to CI pipeline for bench-marking `avx512bf16` dot-product path. The performance should be:
 (1) on `zen5` machine it should be `95%` performance compared to `bf16` tpp-libxsmm run,
 (2) on `emr` machine it should be `~2x` slower compared to `f32` tpp-vector run.
