### PR TITLE
Add contract to mlir-gen

### DIFF
--- a/test/Integration/mlir-gen.mlir
+++ b/test/Integration/mlir-gen.mlir
@@ -8,10 +8,18 @@
 // RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10,10 | tpp-run -e entry -entry-point-result=void
 
 // Matmul only
-// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void
+// RUN: mlir-gen --kernel=const --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=MATMUL
+// RUN: mlir-gen --kernel=const --batch=10 --layers=10,10 --output=generic | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=MATMUL
+// RUN: mlir-gen --kernel=const --batch=10 --layers=10,10 --output=contract | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=MATMUL
+// RUN: mlir-gen --kernel=const --batch=10 --layers=10,10 --output=named | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=MATMUL
+// RUN: mlir-gen --kernel=const --batch=10 --layers=10,10 --output=named --keep-generic-matmul | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=MATMUL
 
 // Constant values
 // RUN: mlir-gen --kernel=const --bias --relu --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=CONSTANT
+// RUN: mlir-gen --kernel=const --bias --relu --batch=10 --layers=10,10 --output=generic | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=CONSTANT
+// RUN: mlir-gen --kernel=const --bias --relu --batch=10 --layers=10,10 --output=contract | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=CONSTANT
+// RUN: mlir-gen --kernel=const --bias --relu --batch=10 --layers=10,10 --output=named | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=CONSTANT
+// RUN: mlir-gen --kernel=const --bias --relu --batch=10 --layers=10,10 --output=named --keep-generic-matmul | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=CONSTANT
 
 // Kernel - matmul
 // RUN: mlir-gen --kernel=args --seed=123 --float-type=f32 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL
@@ -22,6 +30,8 @@
 // Packed versions
 // RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
 // RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+
+// MATMUL:( 10, 10, 10, 10, 10, 10, 10, 10, 10, 10 )
 
 // CONSTANT:( 11, 11, 11, 11, 11, 11, 11, 11, 11, 11 )
 

--- a/tools/mlir-gen/MLIRGen.h
+++ b/tools/mlir-gen/MLIRGen.h
@@ -75,7 +75,7 @@ class MLIRGenerator {
   bool enableSoftmax;
 
   /// List of linalg output Op kind which can be generated
-  enum class OutputOpKind { Generic, NamedOp };
+  enum class OutputOpKind { Generic, Contract, NamedOp };
 
   /// Kind of linalg output Op to be generated
   OutputOpKind outputOpKind;
@@ -155,6 +155,9 @@ class MLIRGenerator {
 
   /// Creates linalg named matmul
   Value lowerNamedMatmul(Value, Value, Value);
+
+  /// Creates linalg contract
+  Value lowerContract(Value, Value, Value);
 
   /// Creates a bias add in the current function
   /// Args: Input, Output (same for in-place)

--- a/tools/mlir-gen/mlir-gen.cpp
+++ b/tools/mlir-gen/mlir-gen.cpp
@@ -33,8 +33,8 @@ using namespace mlir;
 
 // Kind of linalg Op, generic or nameed ops
 llvm::cl::opt<std::string> outputOpKind(
-    "output", llvm::cl::desc("Specifies linalg op kind generic or named"),
-    llvm::cl::value_desc("generic,named"), llvm::cl::init("generic"));
+    "output", llvm::cl::desc("Specifies linalg op kind generic, contract or named"),
+    llvm::cl::value_desc("generic,contract,named"), llvm::cl::init("generic"));
 
 // Enable emission of generic matmul when outputKind is named op
 llvm::cl::opt<bool> keepGenericMatmul(


### PR DESCRIPTION
Adds `linalg.contract` to MLIR Gen so we can start testing contraction inputs.