### PR TITLE
[CMake] Allow passing libxsmm / dnn root to use local builds

### DIFF
--- a/cmake/modules/xsmm-dnn.cmake
+++ b/cmake/modules/xsmm-dnn.cmake
@@ -3,12 +3,8 @@ if (NOT LIBXSMMROOT)
   message(FATAL_ERROR "LIBXSMM is a hard dependency for LIBXSMM-DNN")
 endif()
 
-# Use LIBXSMM_DNN (make PREFIX=/path/to/libxsmm-dnn) given by LIBXSMM_DNNROOT
-set(LIBXSMM_DNNROOT $ENV{LIBXSMM_DNNROOT})
-# Fetch LIBXSMM_DNN (even if LIBXSMM_DNNROOT is present)
-set(LIBXSMM_DNNFETCH $ENV{LIBXSMM_DNNFETCH})
-
-if(LIBXSMM_DNNROOT AND NOT LIBXSMM_DNNFETCH)
+# Make to pass full path to LIBXSMM_DNNROOT
+if(EXISTS ${LIBXSMM_DNNROOT})
   message(STATUS "Found LIBXSMM_DNN (${LIBXSMM_DNNROOT})")
 else()
   message(STATUS "Fetching LIBXSMM_DNN")

--- a/cmake/modules/xsmm.cmake
+++ b/cmake/modules/xsmm.cmake
@@ -1,9 +1,5 @@
-# Use LIBXSMM (make PREFIX=/path/to/libxsmm) given by LIBXSMMROOT
-set(LIBXSMMROOT $ENV{LIBXSMMROOT})
-# Fetch LIBXSMM (even if LIBXSMMROOT is present)
-set(LIBXSMMFETCH $ENV{LIBXSMMFETCH})
-
-if(LIBXSMMROOT AND NOT LIBXSMMFETCH)
+# Make to pass full path to LIBXSMMROOT
+if(EXISTS ${LIBXSMMROOT})
   message(STATUS "Found LIBXSMM (${LIBXSMMROOT})")
   file(GLOB XSMM_SRCS LIST_DIRECTORIES false CONFIGURE_DEPENDS ${LIBXSMMROOT}/include/libxsmm/*.c)
   list(REMOVE_ITEM XSMM_SRCS ${LIBXSMMROOT}/include/libxsmm/libxsmm_generator_gemm_driver.c)


### PR DESCRIPTION
This allows us to set CMake variables to use an existing libxsmm build:
  -DLIBXSMMROOT
  -DLIBXSMM_DNNROOT

Use full paths to make it easier for CMake to find it.