### PR TITLE
[tpp-sched] Make passes which operate on modules operate on modules

### DIFF
--- a/python/mlir/tpp/sched/bundles.py
+++ b/python/mlir/tpp/sched/bundles.py
@@ -340,10 +340,9 @@ def default_pipeline(
     mod = apply_registered_pass(mod, "convert-func-to-llvm")
     mod = apply_registered_pass(mod, "convert-arith-to-llvm")
     mod = apply_registered_pass(mod, "convert-cf-to-llvm")
-    func = match(mod, ops={"func.func"})
     if def_parallel:
-        func = apply_registered_pass(func, "convert-omp-to-llvm")
-    func = apply_registered_pass(func, "convert-ub-to-llvm")
+        mod = apply_registered_pass(mod, "convert-openmp-to-llvm")
+    mod = apply_registered_pass(mod, "convert-ub-to-llvm")
     mod = apply_registered_pass(mod, "canonicalize")
     mod = apply_registered_pass(mod, "cse")
     mod = apply_registered_pass(mod, "reconcile-unrealized-casts")


### PR DESCRIPTION
There was no reason for these passes to only get access to the contained func.func. In case of `-convert-cf-to-llvm` (#1050) it led to the incorrect behaviour.

This corresponds to what is happening in `DefaultPipeline.cpp`.

Also fixes typo "convert-omp-to-llvm" -> "convert-openmp-to-llvm".