### PR TITLE
[tune] Introduce transform.tune.select and tune dialect boilerplate

### DIFF
--- a/include/TPP/Dialect/CMakeLists.txt
+++ b/include/TPP/Dialect/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Check)
 add_subdirectory(Perf)
+add_subdirectory(Tune)
 add_subdirectory(Xsmm)

--- a/include/TPP/Dialect/Tune/CMakeLists.txt
+++ b/include/TPP/Dialect/Tune/CMakeLists.txt
@@ -1,0 +1,9 @@
+#add_mlir_dialect(TuneOps tune)
+#add_mlir_doc(TuneDialect TuneDialect TPP/ -gen-dialect-doc)
+
+set(LLVM_TARGET_DEFINITIONS TuneTransformOps.td)
+mlir_tablegen(TuneTransformOps.h.inc -gen-op-decls)
+mlir_tablegen(TuneTransformOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(TuneTransformOpsIncGen)
+
+add_mlir_doc(TuneTransformOps TuneTransformOps ./ -gen-op-doc)

--- a/include/TPP/Dialect/Tune/TuneDialect.h
+++ b/include/TPP/Dialect/Tune/TuneDialect.h
@@ -1,0 +1,17 @@
+//===- XsmmDialect.h - Xsmm dialect -----------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TPP_DIALECT_TUNE_TUNEDIALECT_H
+#define TPP_DIALECT_TUNE_TUNEDIALECT_H
+
+#include "mlir/IR/Dialect.h"
+
+#define GET_OP_CLASSES
+#include "TPP/Dialect/Tune/TuneOpsDialect.h.inc"
+
+#endif // TPP_DIALECT_TUNE_TUNEDIALECT_H

--- a/include/TPP/Dialect/Tune/TuneDialect.td
+++ b/include/TPP/Dialect/Tune/TuneDialect.td
@@ -1,0 +1,35 @@
+//===- TuneDialect.td - Tune dialect ----------------------*- tablegen -*--===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TPP_TUNE_DIALECT
+#define TPP_TUNE_DIALECT
+
+include "mlir/IR/OpBase.td"
+
+//===----------------------------------------------------------------------===//
+// Tune dialect definition.
+//===----------------------------------------------------------------------===//
+
+def Tune_Dialect : Dialect {
+    let name = "tune";
+    let summary = "Tune dialect.";
+    let description = [{
+        TODO
+    }];
+    let cppNamespace = "::mlir::tune";
+    let usePropertiesForAttributes = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// Base operation definition.
+//===----------------------------------------------------------------------===//
+
+class Tune_Op<string mnemonic, list<Trait> traits = []> :
+        Op<Tune_Dialect, mnemonic, traits>;
+
+#endif // TPP_TUNE_DIALECT

--- a/include/TPP/Dialect/Tune/TuneTransformOps.h
+++ b/include/TPP/Dialect/Tune/TuneTransformOps.h
@@ -1,0 +1,17 @@
+#ifndef MLIR_TUNE_TRANSFORM_OPS_H
+#define MLIR_TUNE_TRANSFORM_OPS_H
+
+#include "mlir/Dialect/Transform/IR/TransformOps.h"
+#include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.h"
+#include "mlir/IR/OpImplementation.h"
+
+#define GET_OP_CLASSES
+#include "TPP/Dialect/Tune/TuneTransformOps.h.inc"
+
+namespace mlir {
+namespace tune {
+void registerTransformDialectExtension(mlir::DialectRegistry &registry);
+} // namespace tune
+} // namespace mlir
+
+#endif // MLIR_TUNE_TRANSFORM_OPS_H

--- a/include/TPP/Dialect/Tune/TuneTransformOps.td
+++ b/include/TPP/Dialect/Tune/TuneTransformOps.td
@@ -1,0 +1,25 @@
+#ifndef TUNE_TRANSFORM_OPS
+#define TUNE_TRANSFORM_OPS
+
+include "mlir/Dialect/Transform/IR/TransformDialect.td"
+include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+
+def TuneSelectOp : Op<Transform_Dialect, "tune.select", [
+  DeclareOpInterfaceMethods<TransformOpInterface>,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+]> {
+  let summary = "Non-deterministically select a value from a set of values";
+  let description = [{
+    TODO
+  }];
+
+  let arguments = (ins SymbolRefAttr:$name,
+                       ArrayAttr:$options);
+  let results = (outs TransformParamTypeInterface:$selected);
+  let assemblyFormat =
+      "$name `from` $options attr-dict `:` functional-type(operands, results)";
+}
+
+#endif // TUNE_TRANSFORM_OPS

--- a/lib/TPP/Dialect/CMakeLists.txt
+++ b/lib/TPP/Dialect/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Check)
 add_subdirectory(Perf)
+add_subdirectory(Tune)
 add_subdirectory(Xsmm)

--- a/lib/TPP/Dialect/Tune/CMakeLists.txt
+++ b/lib/TPP/Dialect/Tune/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(TransformOps)

--- a/lib/TPP/Dialect/Tune/TransformOps/CMakeLists.txt
+++ b/lib/TPP/Dialect/Tune/TransformOps/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_mlir_dialect_library(TuneTransformOps
+  TuneTransformOps.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/TPP
+
+  DEPENDS
+  TuneTransformOpsIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRTransformDialect
+)

--- a/lib/TPP/Dialect/Tune/TransformOps/TuneTransformOps.cpp
+++ b/lib/TPP/Dialect/Tune/TransformOps/TuneTransformOps.cpp
@@ -1,0 +1,49 @@
+#include "TPP/Dialect/Tune/TuneTransformOps.h"
+#include "mlir/Dialect/Transform/IR/TransformOps.h"
+
+using namespace mlir;
+
+#define GET_OP_CLASSES
+#include "TPP/Dialect/Tune/TuneTransformOps.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// TuneSelectOp
+//===----------------------------------------------------------------------===//
+
+void transform::TuneSelectOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  producesHandle(getOperation()->getOpResults(), effects);
+  onlyReadsPayload(effects);
+}
+
+DiagnosedSilenceableFailure
+transform::TuneSelectOp::apply(transform::TransformRewriter &rewriter,
+                               transform::TransformResults &results,
+                               transform::TransformState &state) {
+  return emitDefiniteFailure()
+         << "this op does not have interpreted semantics!";
+}
+
+//===----------------------------------------------------------------------===//
+// Transform op registration
+//===----------------------------------------------------------------------===//
+
+namespace {
+class TuneTransformDialectExtension
+    : public transform::TransformDialectExtension<
+          TuneTransformDialectExtension> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TuneTransformDialectExtension)
+
+  TuneTransformDialectExtension() {
+    registerTransformOps<
+#define GET_OP_LIST
+#include "TPP/Dialect/Tune/TuneTransformOps.cpp.inc"
+        >();
+  }
+};
+} // namespace
+
+void mlir::tune::registerTransformDialectExtension(DialectRegistry &registry) {
+  registry.addExtensions<TuneTransformDialectExtension>();
+}

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -37,6 +37,16 @@ declare_mlir_dialect_python_bindings(
   DIALECT_NAME xsmm
 )
 
+declare_mlir_dialect_extension_python_bindings(
+  ADD_TO_PARENT TPPPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir"
+  TD_FILE dialects/TuneTransformOps.td
+  SOURCES
+  dialects/transform/tune.py
+  DIALECT_NAME transform
+  EXTENSION_NAME tune_transform
+)
+
 declare_mlir_python_extension(TPPPythonSources.DialectExtension
   MODULE_NAME _tppDialects
   ADD_TO_PARENT TPPPythonSources

--- a/python/mlir/dialects/TuneTransformOps.td
+++ b/python/mlir/dialects/TuneTransformOps.td
@@ -1,0 +1,6 @@
+#ifndef TUNE_DIALECTS_EXTENSION_BINDING
+#define TUNE_DIALECTS_EXTENSION_BINDING
+
+include "TPP/Dialect/Tune/TuneTransformOps.td"
+
+#endif // TUNE_DIALECTS_EXTENSION_BINDING

--- a/python/mlir/dialects/transform/tune.py
+++ b/python/mlir/dialects/transform/tune.py
@@ -1,0 +1,25 @@
+from ...ir import *
+from .._tune_transform_ops_gen import *
+
+from collections.abc import Sequence
+from typing import List, Optional, Union
+
+def select(
+    selected: Type, # transform.param or transform.param<...>
+    name: Union[str, Attribute],
+    options: Union[ArrayAttr, Sequence[Attribute]],
+    loc=None,
+    ip=None,
+) -> TuneSelectOp:
+    if isinstance(name, str):
+        name = SymbolRefAttr.get([name])
+    if isinstance(options, Sequence):
+        options = ArrayAttr.get(options)
+
+    return TuneSelectOp(
+        selected=selected,
+        name=name,
+        options=options,
+        loc=loc,
+        ip=ip,
+    )

--- a/tools/tpp-opt/tpp-opt.cpp
+++ b/tools/tpp-opt/tpp-opt.cpp
@@ -27,6 +27,7 @@
 #include "TPP/Dialect/Check/CheckDialect.h"
 #include "TPP/Dialect/Perf/BufferizableOpInterfaceImpl.h"
 #include "TPP/Dialect/Perf/PerfDialect.h"
+#include "TPP/Dialect/Tune/TuneTransformOps.h"
 #include "TPP/Dialect/Xsmm/XsmmDialect.h"
 #include "TPP/PassBundles.h"
 #include "TPP/Passes.h"
@@ -52,6 +53,7 @@ int main(int argc, char **argv) {
   registerAllExtensions(registry);
   mlir::linalg::registerTransformDialectExtension(registry);
   mlir::tensor::registerTransformDialectExtension(registry);
+  mlir::tune::registerTransformDialectExtension(registry);
   registerAllToLLVMIRTranslations(registry);
 
   return mlir::asMainReturnCode(


### PR DESCRIPTION
Can be used to generate syntax which represents a non-deterministic choice. E.g., as follows:
```python
diff --git a/python/mlir/tpp/sched/main.py b/python/mlir/tpp/sched/main.py
index be31fb2e..4f1f6719 100644
--- a/python/mlir/tpp/sched/main.py
+++ b/python/mlir/tpp/sched/main.py
@@ -5,6 +5,7 @@ from argparse import ArgumentParser
 from mlir import ir, passmanager
 from mlir.dialects import transform
 from mlir.dialects import check, perf, xsmm  # Registers our TPP-MLIR dialects.
+from mlir.dialects.transform import tune
 from mlir.dialects.transform import interpreter as transform_interpreter
 
 from . import bundles
@@ -92,6 +93,12 @@ def overall_schedule(**config: Dict[str, Any]) -> ir.Module:
                 op_name="builtin.module",
                 deduplicate=True,
             )
+            i64 = ir.IntegerType.get_signless(64)
+            tune.select(
+                transform.AnyParamType.get(),
+                name="coin_flip",
+                options=[ir.IntegerAttr.get(i64, 0), ir.IntegerAttr.get(i64, 1)],
+            )
 
             try:
                 # Now pass the module handle through the bundles.
```