### PR TITLE
Vectorizer - register blocking

### DIFF
--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -645,6 +645,10 @@ def RegisterBlocking : Pass<"register-blocking", "func::FuncOp"> {
                            "math::MathDialect",
                            "affine::AffineDialect",
                            "arith::ArithDialect"];
+  let options = [
+    ListOption<"blocks", "blocks", "int64_t",
+               "Block sizes for the innermost dims: [M, N, K]">
+  ];
 }
 
 #endif // TPP_DIALECT_TPP_PASSES

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -633,4 +633,18 @@ def GpuVectorize : Pass<"gpu-vectorize", "ModuleOp"> {
                            "vector::VectorDialect"];
 }
 
+def RegisterBlocking : Pass<"register-blocking", "func::FuncOp"> {
+  let summary = "Block ops for register sizes.";
+  let description = [{
+    Tile, fuse, and post-process ops to bring them to hardware-friendly
+    shapes in preparation for vectorization.
+  }];
+  let dependentDialects = ["scf::SCFDialect",
+                           "tensor::TensorDialect",
+                           "linalg::LinalgDialect",
+                           "math::MathDialect",
+                           "affine::AffineDialect",
+                           "arith::ArithDialect"];
+}
+
 #endif // TPP_DIALECT_TPP_PASSES

--- a/lib/TPP/Transforms/CMakeLists.txt
+++ b/lib/TPP/Transforms/CMakeLists.txt
@@ -32,6 +32,7 @@ add_mlir_library(TPPTransforms
   VectorContractToFMA.cpp
   VectorContractToBF16DotProduct.cpp
   VectorContractToAMX.cpp
+  RegisterBlocking.cpp
 
   ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/TPP

--- a/lib/TPP/Transforms/RegisterBlocking.cpp
+++ b/lib/TPP/Transforms/RegisterBlocking.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "TPP/Passes.h"
 #include "TPP/Transforms/Utils/VNNIUtils.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -50,7 +51,7 @@ static SmallVector<IntType> extractVector(ArrayAttr arrayAttr) {
       [](IntegerAttr attr) { return static_cast<IntType>(attr.getInt()); }));
 }
 
-// Returns register blocks for innermost dims: [M, N, K]
+// Returns register blocks for the innermost dims: [M, N, K]
 static SmallVector<int64_t> getRegisterBlocks(Operation *op) {
   auto res = dlti::query(op, {"CPU", "reg_blocks"});
   if (failed(res))
@@ -127,6 +128,9 @@ static void peelTiledLoops(ArrayRef<Operation *> loops,
 struct TileAndFuseContraction : OpInterfaceRewritePattern<linalg::LinalgOp> {
   using OpInterfaceRewritePattern<linalg::LinalgOp>::OpInterfaceRewritePattern;
 
+  TileAndFuseContraction(MLIRContext *ctx, tpp::RegisterBlockingOptions options)
+      : OpInterfaceRewritePattern<linalg::LinalgOp>(ctx), options(options) {}
+
   LogicalResult matchAndRewrite(linalg::LinalgOp matmulOp,
                                 PatternRewriter &rewriter) const override {
     if (!matmulOp.hasPureTensorSemantics())
@@ -157,7 +161,9 @@ struct TileAndFuseContraction : OpInterfaceRewritePattern<linalg::LinalgOp> {
       return rewriter.notifyMatchFailure(
           matmulOp, "expects at only 2 parallel non-batch dimensions");
 
-    SmallVector<int64_t> regBlocks = getRegisterBlocks(matmulOp);
+    SmallVector<int64_t> regBlocks = options.blocks;
+    if (regBlocks.empty())
+      regBlocks = getRegisterBlocks(matmulOp);
     if (regBlocks.size() != 3)
       return rewriter.notifyMatchFailure(matmulOp, "invalid register blocking");
 
@@ -259,6 +265,9 @@ struct TileAndFuseContraction : OpInterfaceRewritePattern<linalg::LinalgOp> {
 
     return success();
   }
+
+private:
+  tpp::RegisterBlockingOptions options;
 };
 
 // Tile reduction dimensions of previously tile-and-fused contraction ops.
@@ -274,6 +283,10 @@ struct TileAndFuseContraction : OpInterfaceRewritePattern<linalg::LinalgOp> {
 struct TileContractionReductionDims
     : OpInterfaceRewritePattern<linalg::LinalgOp> {
   using OpInterfaceRewritePattern<linalg::LinalgOp>::OpInterfaceRewritePattern;
+
+  TileContractionReductionDims(MLIRContext *ctx,
+                               tpp::RegisterBlockingOptions options)
+      : OpInterfaceRewritePattern<linalg::LinalgOp>(ctx), options(options) {}
 
   LogicalResult matchAndRewrite(linalg::LinalgOp matmulOp,
                                 PatternRewriter &rewriter) const override {
@@ -299,7 +312,9 @@ struct TileContractionReductionDims
       return rewriter.notifyMatchFailure(
           matmulOp, "expects at only 2 parallel non-batch dimensions");
 
-    SmallVector<int64_t> regBlocks = getRegisterBlocks(matmulOp);
+    SmallVector<int64_t> regBlocks = options.blocks;
+    if (regBlocks.empty())
+      regBlocks = getRegisterBlocks(matmulOp);
     if (regBlocks.size() != 3)
       return rewriter.notifyMatchFailure(matmulOp, "invalid register blocking");
 
@@ -377,6 +392,9 @@ struct TileContractionReductionDims
 
     return success();
   }
+
+private:
+  tpp::RegisterBlockingOptions options;
 };
 
 struct RegisterBlocking
@@ -387,13 +405,16 @@ struct RegisterBlocking
     auto *ctx = &getContext();
     auto op = getOperation();
 
+    tpp::RegisterBlockingOptions options;
+    options.blocks = SmallVector<int64_t>{*blocks};
+
     GreedyRewriteConfig config;
     config.setStrictness(GreedyRewriteStrictness::ExistingOps);
 
     // First, tile and fuse contraction along parallel dimensions.
     {
       RewritePatternSet patterns(ctx);
-      patterns.add<TileAndFuseContraction>(ctx);
+      patterns.add<TileAndFuseContraction>(ctx, options);
       if (failed(applyPatternsGreedily(op, std::move(patterns), config)))
         return signalPassFailure();
     }
@@ -419,7 +440,7 @@ struct RegisterBlocking
     // Then tile reduction dimensions.
     {
       RewritePatternSet patterns(ctx);
-      patterns.add<TileContractionReductionDims>(ctx);
+      patterns.add<TileContractionReductionDims>(ctx, options);
       if (failed(applyPatternsGreedily(op, std::move(patterns), config)))
         return signalPassFailure();
     }

--- a/lib/TPP/Transforms/RegisterBlocking.cpp
+++ b/lib/TPP/Transforms/RegisterBlocking.cpp
@@ -160,7 +160,7 @@ struct TileAndFuseContraction : OpInterfaceRewritePattern<linalg::LinalgOp> {
     // BRGEMM cases.
     if (dims->m.size() != 1 || dims->n.size() != 1)
       return rewriter.notifyMatchFailure(
-          contractOp, "expects at only 2 parallel non-batch dimensions");
+          contractOp, "expects only 2 parallel (M and N) non-batch dimensions");
 
     SmallVector<int64_t> regBlocks = options.blocks;
     if (regBlocks.empty())
@@ -313,7 +313,7 @@ struct TileContractionReductionDims
     // TODO: Relax constraints.
     if (dims->m.size() != 1 || dims->n.size() != 1)
       return rewriter.notifyMatchFailure(
-          contractOp, "expects at only 2 parallel non-batch dimensions");
+          contractOp, "expects only 2 parallel (M and N) non-batch dimensions");
 
     SmallVector<int64_t> regBlocks = options.blocks;
     if (regBlocks.empty())

--- a/lib/TPP/Transforms/RegisterBlocking.cpp
+++ b/lib/TPP/Transforms/RegisterBlocking.cpp
@@ -131,22 +131,23 @@ struct TileAndFuseContraction : OpInterfaceRewritePattern<linalg::LinalgOp> {
   TileAndFuseContraction(MLIRContext *ctx, tpp::RegisterBlockingOptions options)
       : OpInterfaceRewritePattern<linalg::LinalgOp>(ctx), options(options) {}
 
-  LogicalResult matchAndRewrite(linalg::LinalgOp matmulOp,
+  LogicalResult matchAndRewrite(linalg::LinalgOp contractOp,
                                 PatternRewriter &rewriter) const override {
-    if (!matmulOp.hasPureTensorSemantics())
-      return rewriter.notifyMatchFailure(matmulOp, "expects tensor semantics");
-    if (matmulOp.hasDynamicShape())
-      return rewriter.notifyMatchFailure(matmulOp, "expects static shape");
-    if (llvm::any_of(matmulOp.getIndexingMapsArray(), [](AffineMap map) {
+    if (!contractOp.hasPureTensorSemantics())
+      return rewriter.notifyMatchFailure(contractOp,
+                                         "expects tensor semantics");
+    if (contractOp.hasDynamicShape())
+      return rewriter.notifyMatchFailure(contractOp, "expects static shape");
+    if (llvm::any_of(contractOp.getIndexingMapsArray(), [](AffineMap map) {
           return !map.isProjectedPermutation();
         }))
-      return rewriter.notifyMatchFailure(matmulOp,
+      return rewriter.notifyMatchFailure(contractOp,
                                          "expects projected permutation maps");
 
     FailureOr<linalg::ContractionDimensions> dims =
-        linalg::inferContractionDims(matmulOp);
+        linalg::inferContractionDims(contractOp);
     if (failed(dims))
-      return rewriter.notifyMatchFailure(matmulOp, "not a contraction");
+      return rewriter.notifyMatchFailure(contractOp, "not a contraction");
 
     // Matching is constrained to support only one M and one N dimensions.
     // If multiple are present then it is unclear what they represent and
@@ -159,20 +160,21 @@ struct TileAndFuseContraction : OpInterfaceRewritePattern<linalg::LinalgOp> {
     // BRGEMM cases.
     if (dims->m.size() != 1 || dims->n.size() != 1)
       return rewriter.notifyMatchFailure(
-          matmulOp, "expects at only 2 parallel non-batch dimensions");
+          contractOp, "expects at only 2 parallel non-batch dimensions");
 
     SmallVector<int64_t> regBlocks = options.blocks;
     if (regBlocks.empty())
-      regBlocks = getRegisterBlocks(matmulOp);
+      regBlocks = getRegisterBlocks(contractOp);
     if (regBlocks.size() != 3)
-      return rewriter.notifyMatchFailure(matmulOp, "invalid register blocking");
+      return rewriter.notifyMatchFailure(contractOp,
+                                         "invalid register blocking");
 
     // Tile only along parallel dimensions to allow for fusion.
     //
     // The register blocking is applied to the remaining innermost dimension.
     // Scalarize batch and other parallel dimensions - it is a fallback option,
     // ideally user should've preprocessed them earlier.
-    SmallVector<int64_t> parallelTileSizes(matmulOp.getNumLoops(), 1);
+    SmallVector<int64_t> parallelTileSizes(contractOp.getNumLoops(), 1);
     for (auto dim : dims->k)
       parallelTileSizes[dim] = 0;
     parallelTileSizes[dims->m[0]] = regBlocks[0];
@@ -204,14 +206,14 @@ struct TileAndFuseContraction : OpInterfaceRewritePattern<linalg::LinalgOp> {
       return consumer;
     };
     // Get the last fusable consumer to use for tiling and fusion root.
-    linalg::LinalgOp consumer = matmulOp;
+    linalg::LinalgOp consumer = contractOp;
     while (auto nextConsumer = isFusable(consumer)) {
       consumer = nextConsumer;
     }
     // Map original contraction tile sizes to consumer which has only
     // parallel iterators.
     SmallVector<OpFoldResult> consumerTiles = remapTilesToEltwiseConsumer(
-        consumer, matmulOp,
+        consumer, contractOp,
         getAsOpFoldResult(rewriter.getI64ArrayAttr(parallelTileSizes)));
 
     scf::SCFTilingOptions options;
@@ -221,7 +223,7 @@ struct TileAndFuseContraction : OpInterfaceRewritePattern<linalg::LinalgOp> {
     // Fuse only linalg eltwise ops and the original contraction.
     // However, its profitability is unclear at register (nanokernel) level and
     // it would complicate post-processing logic, thus, disable for now.
-    DominanceInfo domInfo(matmulOp);
+    DominanceInfo domInfo(contractOp);
     scf::SCFTileAndFuseOptions::ControlFnTy controlFn =
         [&](tensor::ExtractSliceOp candidateSliceOp, OpResult originalProducer,
             bool isDestinationOperand)
@@ -230,11 +232,11 @@ struct TileAndFuseContraction : OpInterfaceRewritePattern<linalg::LinalgOp> {
           dyn_cast_or_null<linalg::LinalgOp>(originalProducer.getOwner());
       if (!candidateOp)
         return std::nullopt;
-      if (candidateOp != matmulOp && !linalg::isElementwise(candidateOp))
+      if (candidateOp != contractOp && !linalg::isElementwise(candidateOp))
         return std::nullopt;
       // Fuse only contraction epilogue and data initialization ops.
       if (!isa<linalg::FillOp, linalg::BroadcastOp>(candidateOp) &&
-          !domInfo.dominates(matmulOp, candidateOp))
+          !domInfo.dominates(contractOp, candidateOp))
         return std::nullopt;
       scf::SCFTileAndFuseOptions::ControlFnResult res;
       res.yieldProducerReplacement = false;
@@ -288,47 +290,49 @@ struct TileContractionReductionDims
                                tpp::RegisterBlockingOptions options)
       : OpInterfaceRewritePattern<linalg::LinalgOp>(ctx), options(options) {}
 
-  LogicalResult matchAndRewrite(linalg::LinalgOp matmulOp,
+  LogicalResult matchAndRewrite(linalg::LinalgOp contractOp,
                                 PatternRewriter &rewriter) const override {
     // Only target previously parallel dim tiled and fused operations.
-    auto tiledFusedAttr = matmulOp->getDiscardableAttr(tiledFusedAttrName);
+    auto tiledFusedAttr = contractOp->getDiscardableAttr(tiledFusedAttrName);
     if (!tiledFusedAttr)
       return rewriter.notifyMatchFailure(
-          matmulOp, "only targets previously register blocked ops");
+          contractOp, "only targets previously register blocked ops");
 
-    if (!matmulOp.hasPureTensorSemantics())
-      return rewriter.notifyMatchFailure(matmulOp, "expects tensor semantics");
-    if (matmulOp.hasDynamicShape())
-      return rewriter.notifyMatchFailure(matmulOp, "expects static shape");
+    if (!contractOp.hasPureTensorSemantics())
+      return rewriter.notifyMatchFailure(contractOp,
+                                         "expects tensor semantics");
+    if (contractOp.hasDynamicShape())
+      return rewriter.notifyMatchFailure(contractOp, "expects static shape");
 
     FailureOr<linalg::ContractionDimensions> dims =
-        linalg::inferContractionDims(matmulOp);
+        linalg::inferContractionDims(contractOp);
     if (failed(dims))
-      return rewriter.notifyMatchFailure(matmulOp, "not a contraction");
+      return rewriter.notifyMatchFailure(contractOp, "not a contraction");
 
     // Matching stil requires parallel dimensions to allow for VNNI detection.
     // TODO: Relax constraints.
     if (dims->m.size() != 1 || dims->n.size() != 1)
       return rewriter.notifyMatchFailure(
-          matmulOp, "expects at only 2 parallel non-batch dimensions");
+          contractOp, "expects at only 2 parallel non-batch dimensions");
 
     SmallVector<int64_t> regBlocks = options.blocks;
     if (regBlocks.empty())
-      regBlocks = getRegisterBlocks(matmulOp);
+      regBlocks = getRegisterBlocks(contractOp);
     if (regBlocks.size() != 3)
-      return rewriter.notifyMatchFailure(matmulOp, "invalid register blocking");
+      return rewriter.notifyMatchFailure(contractOp,
+                                         "invalid register blocking");
 
-    auto matA = matmulOp->getOperand(0);
+    auto matA = contractOp->getOperand(0);
     unsigned rankA = dyn_cast<ShapedType>(matA.getType()).getRank();
     AffineMap mapA =
-        matmulOp.getMatchingIndexingMap(&matmulOp->getOpOperand(0));
+        contractOp.getMatchingIndexingMap(&contractOp->getOpOperand(0));
 
     // Find the innermost reduction dimension for tiling.
     // NOTE: It is assumed that all batch-reduce dimensions are outer w.r.t.
     //       K-dim reduce dimensions.
     // In case of VNNI, take the second inner dimension as the VNNI
     // dimension is guaranteed to be the innermost.
-    bool isVnni = vnni::utils::isInVnniLayout(matmulOp);
+    bool isVnni = vnni::utils::isInVnniLayout(contractOp);
     std::optional<unsigned> dimVnni = std::nullopt;
     if (isVnni)
       dimVnni =
@@ -351,7 +355,7 @@ struct TileContractionReductionDims
     //
     // Scalarize other reduction dimensions - it is a fallback option,
     // ideally user should've preprocessed them earlier.
-    SmallVector<int64_t> reductionTileSizes(matmulOp.getNumLoops(), 0);
+    SmallVector<int64_t> reductionTileSizes(contractOp.getNumLoops(), 0);
     for (auto dim : dims->k)
       reductionTileSizes[dim] = 1;
     if (isVnni)
@@ -380,11 +384,11 @@ struct TileContractionReductionDims
     tilingOptions.setInterchange(interchange);
 
     FailureOr<linalg::TiledLinalgOp> tiledOp =
-        linalg::tileLinalgOp(rewriter, matmulOp, tilingOptions);
+        linalg::tileLinalgOp(rewriter, contractOp, tilingOptions);
     if (failed(tiledOp))
-      return rewriter.notifyMatchFailure(matmulOp,
+      return rewriter.notifyMatchFailure(contractOp,
                                          "failed to tile reduction dims");
-    rewriter.replaceOp(matmulOp, tiledOp->tensorResults);
+    rewriter.replaceOp(contractOp, tiledOp->tensorResults);
 
     // Tiling cleanup.
     // It is easier to post-process loops now without need for complex matching.

--- a/lib/TPP/Transforms/RegisterBlocking.cpp
+++ b/lib/TPP/Transforms/RegisterBlocking.cpp
@@ -1,0 +1,433 @@
+//===- RegisterBlocking.cpp --------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Transforms/Utils/VNNIUtils.h"
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/DLTI/DLTI.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
+#include "mlir/Dialect/SCF/Transforms/Transforms.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+
+namespace mlir {
+namespace tpp {
+#define GEN_PASS_DEF_REGISTERBLOCKING
+#include "TPP/Passes.h.inc"
+} // namespace tpp
+} // namespace mlir
+
+namespace {
+
+// Attribute name used as a tile-and-fuse marker.
+constexpr const static llvm::StringLiteral tiledFusedAttrName =
+    "reg_tiled_fused";
+
+// Extracts a vector of integers out of an array attribute.
+template <typename IntType>
+static SmallVector<IntType> extractVector(ArrayAttr arrayAttr) {
+  return llvm::to_vector(llvm::map_range(
+      arrayAttr.getAsRange<IntegerAttr>(),
+      [](IntegerAttr attr) { return static_cast<IntType>(attr.getInt()); }));
+}
+
+// Returns register blocks for innermost dims: [M, N, K]
+static SmallVector<int64_t> getRegisterBlocks(Operation *op) {
+  auto res = dlti::query(op, {"CPU", "reg_blocks"});
+  if (failed(res))
+    return {};
+  auto vals = llvm::dyn_cast<ArrayAttr>(*res);
+  if (!vals)
+    return {};
+  return extractVector<int64_t>(vals);
+}
+
+// Returns position of a dimension corresponding to the given iteration map
+// and an iterator.
+static std::optional<unsigned>
+mapIteratorToDim(PatternRewriter &rewriter, AffineMap map, unsigned iterPos) {
+  return map.getResultPosition(rewriter.getAffineDimExpr(iterPos));
+}
+
+// Propagate the tile specification from producer to consumer. Example,
+// Tile spec producer:  (1,  0, 0,  0, 1,  0)
+// Output map producer: (i, ii, k, kk, j, jj) -> (i, ii, j, jj)
+// Assuming an eltwise consumer, with map:
+// (i, ii, j, jj) -> (i, ii, j, jj) the tiling specification will be:
+// (1, 0, 1, 0).
+static SmallVector<OpFoldResult>
+remapTilesToEltwiseConsumer(linalg::LinalgOp consumer,
+                            linalg::LinalgOp producer,
+                            SmallVector<OpFoldResult> tilesProducer) {
+  if (consumer == producer)
+    return tilesProducer;
+
+  assert(linalg::isElementwise(cast<linalg::LinalgOp>(consumer)) &&
+         "Require eltwise consumer");
+
+  assert(producer.getNumDpsInits() == 1);
+  AffineMap outputMap =
+      producer.getMatchingIndexingMap(&producer.getDpsInitsMutable()[0]);
+  assert(outputMap.isProjectedPermutation());
+  assert(outputMap.getNumDims() == tilesProducer.size());
+  SmallVector<OpFoldResult> eltWiseTiles;
+  for (auto expr : outputMap.getResults()) {
+    eltWiseTiles.push_back(
+        tilesProducer[cast<AffineDimExpr>(expr).getPosition()]);
+  }
+  return eltWiseTiles;
+}
+
+// Apply loop peeling to split tail iterations and allow for
+// canonicalization to ensure all blocked ops operate on static values.
+// Peeling is applied in reverse order from the innermost loop to ensure
+// that all tiling loops are affected.
+//
+// Result is ignored as peeling can fail when tiling cleanly divides
+// a dimension which means there is no need for peeling anyway.
+static void peelTiledLoops(ArrayRef<Operation *> loops,
+                           PatternRewriter &rewriter) {
+  for (Operation *loop : llvm::reverse(loops)) {
+    auto forOp = dyn_cast<scf::ForOp>(loop);
+    assert(forOp && "requires scf.for operation");
+    scf::ForOp partialIteration;
+    (void)scf::peelForLoopAndSimplifyBounds(
+        rewriter, dyn_cast<scf::ForOp>(loop), partialIteration);
+  }
+}
+
+// Tile and fuse contraction ops.
+// Uses a contraction op as a root and greedily fuses its elementwise consumers.
+// Additionally, data initialization producers like fills are also fused.
+//
+// Peeling is applied to tiling loops to eliminate dynamic shapes in cases
+// when original operands' shapes are not perfectly divisible by the tiles.
+//
+// Currently, only the innermost GEMM dimensions are tiled.
+// If present, other parallel dimensions are tiled by one.
+struct TileAndFuseContraction : OpInterfaceRewritePattern<linalg::LinalgOp> {
+  using OpInterfaceRewritePattern<linalg::LinalgOp>::OpInterfaceRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::LinalgOp matmulOp,
+                                PatternRewriter &rewriter) const override {
+    if (!matmulOp.hasPureTensorSemantics())
+      return rewriter.notifyMatchFailure(matmulOp, "expects tensor semantics");
+    if (matmulOp.hasDynamicShape())
+      return rewriter.notifyMatchFailure(matmulOp, "expects static shape");
+    if (llvm::any_of(matmulOp.getIndexingMapsArray(), [](AffineMap map) {
+          return !map.isProjectedPermutation();
+        }))
+      return rewriter.notifyMatchFailure(matmulOp,
+                                         "expects projected permutation maps");
+
+    FailureOr<linalg::ContractionDimensions> dims =
+        linalg::inferContractionDims(matmulOp);
+    if (failed(dims))
+      return rewriter.notifyMatchFailure(matmulOp, "not a contraction");
+
+    // Matching is constrained to support only one M and one N dimensions.
+    // If multiple are present then it is unclear what they represent and
+    // how the register blocking (currently assumed to control only 3
+    // dimensions) maps to them.
+    // This could be generalized or the constrain can remain in place if
+    // the operation is expected to be preprocessed earlier.
+    //
+    // Multiple reduction dimensions must be supported to handle VNNI and
+    // BRGEMM cases.
+    if (dims->m.size() != 1 || dims->n.size() != 1)
+      return rewriter.notifyMatchFailure(
+          matmulOp, "expects at only 2 parallel non-batch dimensions");
+
+    SmallVector<int64_t> regBlocks = getRegisterBlocks(matmulOp);
+    if (regBlocks.size() != 3)
+      return rewriter.notifyMatchFailure(matmulOp, "invalid register blocking");
+
+    // Tile only along parallel dimensions to allow for fusion.
+    //
+    // The register blocking is applied to the remaining innermost dimension.
+    // Scalarize batch and other parallel dimensions - it is a fallback option,
+    // ideally user should've preprocessed them earlier.
+    SmallVector<int64_t> parallelTileSizes(matmulOp.getNumLoops(), 1);
+    for (auto dim : dims->k)
+      parallelTileSizes[dim] = 0;
+    parallelTileSizes[dims->m[0]] = regBlocks[0];
+    parallelTileSizes[dims->n[0]] = regBlocks[1];
+
+    // Greedily fuse elementwise consumers.
+    auto isFusable = [](linalg::LinalgOp producer) -> linalg::LinalgOp {
+      // Producer constraints.
+      if (producer->getNumResults() != 1)
+        return nullptr;
+      auto producerRes = producer->getResult(0);
+      // Multiple uses even within the same user introduce recomputation.
+      // To avoid worst-case GEMM duplication, fusion is more conservative here.
+      if (!producerRes.hasOneUse())
+        return nullptr;
+      // Consumer constraints.
+      auto consumer = dyn_cast<linalg::LinalgOp>(*producerRes.user_begin());
+      if (!consumer || consumer->getNumResults() != 1 ||
+          !linalg::isElementwise(consumer))
+        return nullptr;
+      // Require same iteration space.
+      if (producer.getNumParallelLoops() != consumer.getNumParallelLoops())
+        return nullptr;
+      // Require same shapes to avoid any dimension permutations.
+      // TODO: Relax this constraint.
+      if (producer.getShape(&producer.getDpsInitsMutable()[0]) !=
+          consumer.getShape(&consumer.getDpsInitsMutable()[0]))
+        return nullptr;
+      return consumer;
+    };
+    // Get the last fusable consumer to use for tiling and fusion root.
+    linalg::LinalgOp consumer = matmulOp;
+    while (auto nextConsumer = isFusable(consumer)) {
+      consumer = nextConsumer;
+    }
+    // Map original contraction tile sizes to consumer which has only
+    // parallel iterators.
+    SmallVector<OpFoldResult> consumerTiles = remapTilesToEltwiseConsumer(
+        consumer, matmulOp,
+        getAsOpFoldResult(rewriter.getI64ArrayAttr(parallelTileSizes)));
+
+    scf::SCFTilingOptions options;
+    options.setTileSizes(consumerTiles);
+    scf::SCFTileAndFuseOptions tileAndFuseOptions;
+    tileAndFuseOptions.setTilingOptions(options);
+    // Fuse only linalg eltwise ops and the original contraction.
+    // However, its profitability is unclear at register (nanokernel) level and
+    // it would complicate post-processing logic, thus, disable for now.
+    DominanceInfo domInfo(matmulOp);
+    scf::SCFTileAndFuseOptions::ControlFnTy controlFn =
+        [&](tensor::ExtractSliceOp candidateSliceOp, OpResult originalProducer,
+            bool isDestinationOperand)
+        -> std::optional<scf::SCFTileAndFuseOptions::ControlFnResult> {
+      auto candidateOp =
+          dyn_cast_or_null<linalg::LinalgOp>(originalProducer.getOwner());
+      if (!candidateOp)
+        return std::nullopt;
+      if (candidateOp != matmulOp && !linalg::isElementwise(candidateOp))
+        return std::nullopt;
+      // Fuse only contraction epilogue and data initialization ops.
+      if (!isa<linalg::FillOp, linalg::BroadcastOp>(candidateOp) &&
+          !domInfo.dominates(matmulOp, candidateOp))
+        return std::nullopt;
+      scf::SCFTileAndFuseOptions::ControlFnResult res;
+      res.yieldProducerReplacement = false;
+      return res;
+    };
+    tileAndFuseOptions.setFusionControlFn(controlFn);
+
+    FailureOr<scf::SCFTileAndFuseResult> tileAndFuseResult =
+        scf::tileConsumerAndFuseProducersUsingSCF(
+            rewriter, cast<TilingInterface>(consumer.getOperation()),
+            tileAndFuseOptions);
+    if (failed(tileAndFuseResult))
+      return rewriter.notifyMatchFailure(
+          consumer, "failed to tile and fuse with op as root");
+
+    rewriter.replaceOp(consumer,
+                       tileAndFuseResult->replacements[consumer->getResult(0)]);
+
+    // Mark all preprocessed ops to allow easier matching for further passes.
+    for (auto *op : tileAndFuseResult->tiledAndFusedOps)
+      op->setDiscardableAttr(tiledFusedAttrName, rewriter.getUnitAttr());
+
+    // Tiling cleanup.
+    // It is easier to post-process loops now without need for complex matching.
+    peelTiledLoops(SmallVector<Operation *>(tileAndFuseResult->loops.begin(),
+                                            tileAndFuseResult->loops.end()),
+                   rewriter);
+
+    return success();
+  }
+};
+
+// Tile reduction dimensions of previously tile-and-fused contraction ops.
+// It is a follow-up pattern to finalize tiling of a root contraction op
+// processed by the tile and fuse pattern.
+//
+// Peeling is applied to tiling loops to eliminate dynamic shapes in cases
+// when original operands' shapes are not perfectly divisible by the tiles.
+//
+// Currently, only the GEMM K-dimension is tiled.
+// If present, VNNI dimensions remains untiled and other reduction dimensions
+// are tiled by one.
+struct TileContractionReductionDims
+    : OpInterfaceRewritePattern<linalg::LinalgOp> {
+  using OpInterfaceRewritePattern<linalg::LinalgOp>::OpInterfaceRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::LinalgOp matmulOp,
+                                PatternRewriter &rewriter) const override {
+    // Only target previously parallel dim tiled and fused operations.
+    auto tiledFusedAttr = matmulOp->getDiscardableAttr(tiledFusedAttrName);
+    if (!tiledFusedAttr)
+      return rewriter.notifyMatchFailure(
+          matmulOp, "only targets previously register blocked ops");
+
+    if (!matmulOp.hasPureTensorSemantics())
+      return rewriter.notifyMatchFailure(matmulOp, "expects tensor semantics");
+    if (matmulOp.hasDynamicShape())
+      return rewriter.notifyMatchFailure(matmulOp, "expects static shape");
+
+    FailureOr<linalg::ContractionDimensions> dims =
+        linalg::inferContractionDims(matmulOp);
+    if (failed(dims))
+      return rewriter.notifyMatchFailure(matmulOp, "not a contraction");
+
+    // Matching stil requires parallel dimensions to allow for VNNI detection.
+    // TODO: Relax constraints.
+    if (dims->m.size() != 1 || dims->n.size() != 1)
+      return rewriter.notifyMatchFailure(
+          matmulOp, "expects at only 2 parallel non-batch dimensions");
+
+    SmallVector<int64_t> regBlocks = getRegisterBlocks(matmulOp);
+    if (regBlocks.size() != 3)
+      return rewriter.notifyMatchFailure(matmulOp, "invalid register blocking");
+
+    auto matA = matmulOp->getOperand(0);
+    unsigned rankA = dyn_cast<ShapedType>(matA.getType()).getRank();
+    AffineMap mapA =
+        matmulOp.getMatchingIndexingMap(&matmulOp->getOpOperand(0));
+
+    // Find the innermost reduction dimension for tiling.
+    // NOTE: It is assumed that all batch-reduce dimensions are outer w.r.t.
+    //       K-dim reduce dimensions.
+    // In case of VNNI, take the second inner dimension as the VNNI
+    // dimension is guaranteed to be the innermost.
+    bool isVnni = vnni::utils::isInVnniLayout(matmulOp);
+    std::optional<unsigned> dimVnni = std::nullopt;
+    if (isVnni)
+      dimVnni =
+          dyn_cast<AffineDimExpr>(mapA.getResult(rankA - 1)).getPosition();
+    unsigned dimK = 0;
+    int innermostDim = -1;
+    for (auto pos : dims->k) {
+      auto dimPos = mapIteratorToDim(rewriter, mapA, pos);
+      assert(dimPos && "failed to map iterator to dim");
+      if (static_cast<int>(*dimPos) > innermostDim &&
+          (!isVnni || pos != *dimVnni)) {
+        innermostDim = *dimPos;
+        dimK = pos;
+      }
+    }
+
+    // Tile only the innermost K-dim reduction dimension.
+    // Do not tile the VNNI dimension if present.
+    // Disable tiling along parallel dimensions to avoid unnecessary work.
+    //
+    // Scalarize other reduction dimensions - it is a fallback option,
+    // ideally user should've preprocessed them earlier.
+    SmallVector<int64_t> reductionTileSizes(matmulOp.getNumLoops(), 0);
+    for (auto dim : dims->k)
+      reductionTileSizes[dim] = 1;
+    if (isVnni)
+      reductionTileSizes[*dimVnni] = 0;
+    reductionTileSizes[dimK] = regBlocks[2];
+
+    // Place parallel dimensions first as outer loops.
+    // Move batch-reduce dimensions inside, then K-dim reductions.
+    // Keep VNNI innermost if present.
+    SmallVector<unsigned> interchange;
+    interchange.append(dims->batch);
+    interchange.append(dims->m);
+    interchange.append(dims->n);
+    for (auto redDim : dims->k) {
+      if (redDim != dimK && ((!isVnni || redDim != *dimVnni)))
+        interchange.push_back(redDim);
+    }
+    interchange.push_back(dimK);
+    if (isVnni)
+      interchange.push_back(*dimVnni);
+
+    // Apply tiling and replace the original op.
+    linalg::LinalgTilingOptions tilingOptions;
+    tilingOptions.setLoopType(linalg::LinalgTilingLoopType::Loops);
+    tilingOptions.setTileSizes(reductionTileSizes);
+    tilingOptions.setInterchange(interchange);
+
+    FailureOr<linalg::TiledLinalgOp> tiledOp =
+        linalg::tileLinalgOp(rewriter, matmulOp, tilingOptions);
+    if (failed(tiledOp))
+      return rewriter.notifyMatchFailure(matmulOp,
+                                         "failed to tile reduction dims");
+    rewriter.replaceOp(matmulOp, tiledOp->tensorResults);
+
+    // Tiling cleanup.
+    // It is easier to post-process loops now without need for complex matching.
+    peelTiledLoops(tiledOp->loops, rewriter);
+
+    return success();
+  }
+};
+
+struct RegisterBlocking
+    : public tpp::impl::RegisterBlockingBase<RegisterBlocking> {
+  using RegisterBlockingBase::RegisterBlockingBase;
+
+  void runOnOperation() override {
+    auto *ctx = &getContext();
+    auto op = getOperation();
+
+    GreedyRewriteConfig config;
+    config.setStrictness(GreedyRewriteStrictness::ExistingOps);
+
+    // First, tile and fuse contraction along parallel dimensions.
+    {
+      RewritePatternSet patterns(ctx);
+      patterns.add<TileAndFuseContraction>(ctx);
+      if (failed(applyPatternsGreedily(op, std::move(patterns), config)))
+        return signalPassFailure();
+    }
+    // Canonicalization patterns to remove dynamic dimensions after loop
+    // peeling.
+    FrozenRewritePatternSet cleanupPatterns;
+    {
+      RewritePatternSet patterns(ctx);
+      ctx->getLoadedDialect<linalg::LinalgDialect>()
+          ->getCanonicalizationPatterns(patterns);
+      ctx->getLoadedDialect<tensor::TensorDialect>()
+          ->getCanonicalizationPatterns(patterns);
+      tensor::ExtractSliceOp::getCanonicalizationPatterns(patterns, ctx);
+      tensor::InsertSliceOp::getCanonicalizationPatterns(patterns, ctx);
+      tensor::CastOp::getCanonicalizationPatterns(patterns, ctx);
+      scf::ForOp::getCanonicalizationPatterns(patterns, ctx);
+      cleanupPatterns = std::move(patterns);
+    }
+    GreedyRewriteConfig cleanupConfig;
+    if (failed(applyPatternsGreedily(op, cleanupPatterns, cleanupConfig)))
+      return signalPassFailure();
+
+    // Then tile reduction dimensions.
+    {
+      RewritePatternSet patterns(ctx);
+      patterns.add<TileContractionReductionDims>(ctx);
+      if (failed(applyPatternsGreedily(op, std::move(patterns), config)))
+        return signalPassFailure();
+    }
+    if (failed(applyPatternsGreedily(op, cleanupPatterns, cleanupConfig)))
+      return signalPassFailure();
+
+    // TODO: Add tiling and fusion for remaining ops like unfused eltwise
+    //       operations.
+  }
+};
+} // namespace

--- a/lib/TPP/Transforms/RegisterBlocking.cpp
+++ b/lib/TPP/Transforms/RegisterBlocking.cpp
@@ -64,8 +64,9 @@ static SmallVector<int64_t> getRegisterBlocks(Operation *op) {
 
 // Returns position of a dimension corresponding to the given iteration map
 // and an iterator.
-static std::optional<unsigned>
-mapIteratorToDim(PatternRewriter &rewriter, AffineMap map, unsigned iterPos) {
+static std::optional<unsigned> mapIteratorToDimPos(PatternRewriter &rewriter,
+                                                   AffineMap map,
+                                                   unsigned iterPos) {
   return map.getResultPosition(rewriter.getAffineDimExpr(iterPos));
 }
 
@@ -340,7 +341,7 @@ struct TileContractionReductionDims
     unsigned dimK = 0;
     int innermostDim = -1;
     for (auto pos : dims->k) {
-      auto dimPos = mapIteratorToDim(rewriter, mapA, pos);
+      auto dimPos = mapIteratorToDimPos(rewriter, mapA, pos);
       assert(dimPos && "failed to map iterator to dim");
       if (static_cast<int>(*dimPos) > innermostDim &&
           (!isVnni || pos != *dimVnni)) {

--- a/test/Passes/register-blocking.mlir
+++ b/test/Passes/register-blocking.mlir
@@ -211,6 +211,41 @@ func.func @peel_remainder_block(
 
 // -----
 
+!matA = tensor<3x5x256x16x2xbf16>
+!matB = tensor<3x5x16x128x2xbf16>
+!matC = tensor<256x128xbf16>
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d5, d0, d2, d4, d1)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d5, d0, d4, d3, d1)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d3)>
+func.func @tile_multiple_reduction_dims_vnni(
+  %arg0: !matA, %arg1: !matB, %arg2: !matC) -> !matC
+  attributes {
+    dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<
+      #dlti.dl_entry<"reg_blocks", [8, 32, 4]>
+  >>}
+{
+  %0 = linalg.contract
+    indexing_maps = [#map, #map1, #map2]
+    ins(%arg0, %arg1 : !matA, !matB)
+    outs(%arg2 : !matC) -> !matC
+  return %0 : !matC
+}
+
+// Validate that:
+//   - parallel loops are tiled as specified
+//   - K-dim is tiled as specified
+//   - VNNI dim remains untiled
+//   - other reduction dimensions are tiled by one
+
+// CHECK-LABEL: @tile_multiple_reduction_dims_vnni
+// CHECK-COUNT-5: scf.for
+// CHECK:      linalg.contract
+// CHECK-SAME:   ins({{.*}}: tensor<1x1x8x4x2xbf16>, tensor<1x1x4x32x2xbf16>)
+// CHECK-SAME:   outs({{.*}}: tensor<8x32xbf16>)
+
+// -----
+
 !matA = tensor<4x32x64x16xf32>
 !matB = tensor<4x32x16x32xf32>
 !matC = tensor<4x4x64x32xf32>

--- a/test/Passes/register-blocking.mlir
+++ b/test/Passes/register-blocking.mlir
@@ -246,6 +246,34 @@ func.func @tile_multiple_reduction_dims_vnni(
 
 // -----
 
+!matA = tensor<4x48xf32>
+!matB = tensor<48x128xf32>
+!matC = tensor<4x128xf32>
+func.func @tile_small_dims(
+  %arg0: !matA, %arg1: !matB, %arg2: !matC) -> !matC
+  attributes {
+    dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<
+      #dlti.dl_entry<"reg_blocks", [6, 32, 64]>
+  >>}
+{
+  %0 = linalg.matmul ins(%arg0, %arg1 : !matA, !matB)
+    outs(%arg2 : !matC) -> !matC
+  return %0 : !matC
+}
+
+// Validate that partial tiling is still performed when dimensions
+// smaller than tiles sizes are present.
+// Expects to tile N dim, and leave M and K dims untiled.
+
+// CHECK-LABEL: @tile_small_dims
+// CHECK-COUNT-1: scf.for
+// CHECK:      linalg.matmul
+// CHECK-SAME:   ins({{.*}}: tensor<4x48xf32>, tensor<48x32xf32>)
+// CHECK-SAME:   outs({{.*}}: tensor<4x32xf32>)
+
+// -----
+
 !matA = tensor<4x32x64x16xf32>
 !matB = tensor<4x32x16x32xf32>
 !matC = tensor<4x4x64x32xf32>

--- a/test/Passes/register-blocking.mlir
+++ b/test/Passes/register-blocking.mlir
@@ -51,7 +51,7 @@ func.func @batch_matmul(
 }
 
 // Check that batch dimension is tiled by 1.
-// Loops reordered should be as follows:
+// Loops order should be as follows:
 //   - batch dimension
 //   - parallel dimensions
 //   - reduction dimension
@@ -127,7 +127,7 @@ func.func @brgemm_vnni(
   return %0 : !matC
 }
 
-// VNNI dimension must remains untiled.
+// VNNI dimension must remain untiled.
 // To achieve that, generic's iterator loops, affine maps, and operands' shapes
 // must be correctly matched.
 
@@ -183,8 +183,9 @@ func.func @peel_remainder_block(
   return %0 : !matC
 }
 
-// Check that the last block is peeled for not perfectly divisible tile sizes.
-// There must not be any dynamic shapes in this case.
+// Check that the last block is peeled when a dimension is not perfectly
+// divisible by a tile sizes.
+// This ensures there are no dynamic shapes after tiling.
 
 // CHECK-LABEL: @peel_remainder_block(
 // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
@@ -474,9 +475,6 @@ func.func @fuse_only_eltwise_consumers(
 
 // -----
 
-// Do not fuse consumers with multiple uses (even if it has only one user)
-// to avoid introducing recomputations.
-
 !matA = tensor<256x512xf32>
 !matB = tensor<512x128xf32>
 !matC = tensor<256x128xf32>
@@ -494,6 +492,9 @@ func.func @negative_fuse_multi_use_consumer(
     outs(%0 : !matC) -> !matC
   return %1 : !matC
 }
+
+// Do not fuse consumers with multiple uses (even if it has only one user)
+// to avoid introducing recomputations.
 
 // CHECK-LABEL: @negative_fuse_multi_use_consumer
 // CHECK-COUNT-3: scf.for

--- a/test/Passes/register-blocking.mlir
+++ b/test/Passes/register-blocking.mlir
@@ -1,0 +1,476 @@
+// RUN: tpp-opt %s -register-blocking -split-input-file | FileCheck %s
+
+!matA = tensor<256x512xf32>
+!matB = tensor<512x128xf32>
+!matC = tensor<256x128xf32>
+func.func @matmul(
+  %arg0: !matA, %arg1: !matB, %arg2: !matC) -> !matC
+  attributes {
+    dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<
+      #dlti.dl_entry<"reg_blocks", [2, 32, 1]>
+  >>}
+{
+  %0 = linalg.matmul ins(%arg0, %arg1 : !matA, !matB)
+    outs(%arg2 : !matC) -> !matC
+  return %0 : !matC
+}
+
+// CHECK-LABEL: @matmul
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG: %[[C32:.+]] = arith.constant 32 : index
+// CHECK-DAG: %[[C128:.+]] = arith.constant 128 : index
+// CHECK-DAG: %[[C256:.+]] = arith.constant 256 : index
+// CHECK-DAG: %[[C512:.+]] = arith.constant 512 : index
+// Matrix C block loops for M and N dims
+// CHECK: scf.for %{{.+}} = %[[C0]] to %[[C256]] step %[[C2]]
+// CHECK:   scf.for %{{.+}} = %[[C0]] to %[[C128]] step %[[C32]]
+// Reduction loop for K dim
+// CHECK:      scf.for %{{.+}} = %[[C0]] to %[[C512]] step %[[C1]]
+// CHECK:        linalg.matmul{{.*}}ins({{.*}}: tensor<2x1xf32>, tensor<1x32xf32>)
+// CHECK-SAME:   -> tensor<2x32xf32>
+
+// -----
+
+!matA = tensor<16x256x512xf32>
+!matB = tensor<16x512x128xf32>
+!matC = tensor<16x256x128xf32>
+func.func @batch_matmul(
+  %arg0: !matA, %arg1: !matB, %arg2: !matC) -> !matC
+  attributes {
+    dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<
+      #dlti.dl_entry<"reg_blocks", [2, 32, 4]>
+  >>}
+{
+  %0 = linalg.batch_matmul ins(%arg0, %arg1 : !matA, !matB)
+    outs(%arg2 : !matC) -> !matC
+  return %0 : !matC
+}
+
+// Check that batch dimension is tiled by 1.
+// Loops reordered should be as follows:
+//   - batch dimension
+//   - parallel dimensions
+//   - reduction dimension
+
+// CHECK-LABEL: @batch_matmul
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[C16:.+]] = arith.constant 16 : index
+// Fallback - unit step batch dim loop
+// CHECK: scf.for %{{.+}} = %[[C0]] to %[[C16]] step %[[C1]]
+// CHECK-COUNT-3: scf.for
+// CHECK:      linalg.batch_matmul
+// CHECK-SAME:   ins({{.*}}: tensor<1x2x4xf32>, tensor<1x4x32xf32>)
+// CHECK-SAME:   -> tensor<1x2x32xf32>
+
+// -----
+
+!matA = tensor<16x256x512xf32>
+!matB = tensor<16x512x128xf32>
+!matC = tensor<256x128xf32>
+func.func @batch_reduce_matmul(
+  %arg0: !matA, %arg1: !matB, %arg2: !matC) -> !matC
+  attributes {
+    dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<
+      #dlti.dl_entry<"reg_blocks", [2, 32, 4]>
+  >>}
+{
+  %0 = linalg.batch_reduce_matmul ins(%arg0, %arg1 : !matA, !matB)
+    outs(%arg2 : !matC) -> !matC
+  return %0 : !matC
+}
+
+// CHECK-LABEL: @batch_reduce_matmul
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[C16:.+]] = arith.constant 16 : index
+// Matrix C block loops for M and N dims
+// CHECK-COUNT-2: scf.for
+// Fallback - unit step batch reduction dim loop
+// CHECK: scf.for %{{.+}} = %[[C0]] to %[[C16]] step %[[C1]]
+// Reduction loop for K dim
+// CHECK-COUNT-1: scf.for
+// CHECK:      linalg.batch_reduce_matmul
+// CHECK-SAME:   ins({{.*}}: tensor<1x2x4xf32>, tensor<1x4x32xf32>)
+// CHECK-SAME:   -> tensor<2x32xf32>
+
+// -----
+
+!matA = tensor<5x256x16x2xbf16>
+!matB = tensor<5x16x128x2xbf16>
+!matC = tensor<256x128xbf16>
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
+func.func @brgemm_vnni(
+  %arg0: !matA, %arg1: !matB, %arg2: !matC) -> !matC
+  attributes {
+    dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<
+      #dlti.dl_entry<"reg_blocks", [4, 32, 1]>
+  >>}
+{
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2],
+    iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]}
+    ins(%arg0, %arg1 : !matA, !matB)
+    outs(%arg2 : !matC) {
+  ^bb0(%in: bf16, %in_1: bf16, %out: bf16):
+    %1 = arith.mulf %in, %in_1 : bf16
+    %2 = arith.addf %out, %1 : bf16
+    linalg.yield %2 : bf16
+  } -> !matC
+  return %0 : !matC
+}
+
+// VNNI dimension must remains untiled.
+// To achieve that, generic's iterator loops, affine maps, and operands' shapes
+// must be correctly matched.
+
+// CHECK-LABEL: @brgemm_vnni
+// CHECK-COUNT-4: scf.for
+// CHECK:      linalg.generic
+// CHECK-SAME:   ins({{.*}}: tensor<1x4x1x2xbf16>, tensor<1x1x32x2xbf16>)
+// CHECK-SAME:   outs({{.*}}: tensor<4x32xbf16>)
+
+// -----
+
+!matA = tensor<512x256xf32>
+!matB = tensor<512x128xf32>
+!matC = tensor<256x128xf32>
+func.func @matmul_transpose_a(
+  %arg0: !matA, %arg1: !matB, %arg2: !matC) -> !matC
+  attributes {
+    dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<
+      #dlti.dl_entry<"reg_blocks", [2, 32, 1]>
+  >>}
+{
+  %0 = linalg.matmul
+    indexing_maps = [affine_map<(m, n, k) -> (k, m)>, // transpose
+                     affine_map<(m, n, k) -> (k, n)>,
+                     affine_map<(m, n, k) -> (m, n)>]
+    ins(%arg0, %arg1 : !matA, !matB)
+    outs(%arg2 : !matC) -> !matC
+  return %0 : !matC
+}
+
+// CHECK-LABEL: @matmul_transpose_a
+// CHECK-COUNT-3: scf.for
+// CHECK:      linalg.matmul
+// CHECK-SAME:   ins({{.*}}: tensor<1x2xf32>, tensor<1x32xf32>)
+// CHECK-SAME:   outs({{.*}}: tensor<2x32xf32>)
+
+// -----
+
+!matA = tensor<256x512xf32>
+!matB = tensor<512x128xf32>
+!matC = tensor<256x128xf32>
+func.func @peel_remainder_block(
+  %arg0: !matA, %arg1: !matB, %arg2: !matC) -> !matC
+  attributes {
+    dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<
+      #dlti.dl_entry<"reg_blocks", [6, 32, 1]>
+  >>}
+{
+  %0 = linalg.matmul ins(%arg0, %arg1 : !matA, !matB)
+    outs(%arg2 : !matC) -> !matC
+  return %0 : !matC
+}
+
+// Check that the last block is peeled for not perfectly divisible tile sizes.
+// There must not be any dynamic shapes in this case.
+
+// CHECK-LABEL: @peel_remainder_block(
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[C6:.+]] = arith.constant 6 : index
+// CHECK-DAG: %[[C32:.+]] = arith.constant 32 : index
+// CHECK-DAG: %[[C128:.+]] = arith.constant 128 : index
+// CHECK-DAG: %[[C252:.+]] = arith.constant 252 : index
+// Matrix C block loops for M and N dims [full tiles]
+// CHECK:         scf.for %{{.+}} = %[[C0]] to %[[C252]] step %[[C6]]
+// CHECK:           scf.for %{{.+}} = %[[C0]] to %[[C128]] step %[[C32]]
+// Reduction loop for K dim
+// CHECK:      scf.for
+// CHECK:        linalg.matmul
+// CHECK-SAME:     ins({{.*}}: tensor<6x1xf32>, tensor<1x32xf32>)
+// CHECK-SAME:     outs({{.*}}: tensor<6x32xf32>)
+// Tail block loops [remainder tile]
+// Peeled M dim block offsets and shapes are statically know and don't require a loop.
+// Thus, only loops for the N and the K dims are present here.
+// CHECK-COUNT-2: scf.for
+// CHECK:           linalg.matmul
+// CHECK-SAME:        ins({{.*}}: tensor<4x1xf32>, tensor<1x32xf32>)
+// CHECK-SAME:        outs({{.*}}: tensor<4x32xf32>)
+
+// -----
+
+!matA = tensor<4x32x64x16xf32>
+!matB = tensor<4x32x16x32xf32>
+!matC = tensor<4x4x64x32xf32>
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+func.func @negative_tile_multiple_parallel_dims(
+  %arg0: !matA, %arg1: !matB, %arg2: !matC) -> !matC
+  attributes {
+    dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<
+      #dlti.dl_entry<"reg_blocks", [2, 32, 1]>
+  >>}
+{
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+    ins(%arg0, %arg1 : !matA, !matB)
+    outs(%arg2 : !matC) {
+  ^bb0(%in: f32, %in_1: f32, %out: f32):
+    %1 = arith.mulf %in, %in_1 : f32
+    %2 = arith.addf %out, %1 : f32
+    linalg.yield %2 : f32
+  } -> !matC
+  return %0 : !matC
+}
+
+// CHECK-LABEL: @negative_tile_multiple_parallel_dims
+// CHECK-NOT: scf.for
+// CHECK:     linalg.generic
+
+// -----
+
+!matA = tensor<256x512xf32>
+!matB = tensor<512x128xf32>
+!matC = tensor<256x128xf32>
+func.func @negative_invalid_blocking_opt(
+  %arg0: !matA, %arg1: !matB, %arg2: !matC) -> !matC
+  attributes {
+    dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<
+      #dlti.dl_entry<"reg_blocks", [2]>
+  >>}
+{
+  %0 = linalg.matmul ins(%arg0, %arg1 : !matA, !matB)
+    outs(%arg2 : !matC) -> !matC
+  return %0 : !matC
+}
+
+// CHECK-LABEL: @negative_invalid_blocking_opt
+// CHECK-NOT: scf.for
+// CHECK:     linalg.matmul
+
+// -----
+
+!matA = memref<256x512xf32>
+!matB = memref<512x128xf32>
+!matC = memref<256x128xf32>
+func.func @negative_tile_memref(
+  %arg0: !matA, %arg1: !matB, %arg2: !matC)
+  attributes {
+    dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<
+      #dlti.dl_entry<"reg_blocks", [2, 32, 1]>
+  >>}
+{
+  linalg.matmul ins(%arg0, %arg1 : !matA, !matB) outs(%arg2 : !matC)
+  return
+}
+
+// CHECK-LABEL: @negative_tile_memref
+// CHECK-NOT: scf.for
+// CHECK:     linalg.matmul
+
+// -----
+
+!matA = memref<256x?xf32>
+!matB = memref<?x128xf32>
+!matC = memref<256x128xf32>
+func.func @negative_tile_dynamic_shapes(
+  %arg0: !matA, %arg1: !matB, %arg2: !matC)
+  attributes {
+    dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<
+      #dlti.dl_entry<"reg_blocks", [2, 32, 1]>
+  >>}
+{
+  linalg.matmul ins(%arg0, %arg1 : !matA, !matB) outs(%arg2 : !matC)
+  return
+}
+
+// CHECK-LABEL: @negative_tile_dynamic_shapes
+// CHECK-NOT: scf.for
+// CHECK:     linalg.matmul
+
+// -----
+
+!matA = tensor<256x512x3xf32>
+!matB = tensor<512x128x3xf32>
+!matC = tensor<256x128xf32>
+func.func @negative_tile_non_projected_permutation(
+  %arg0: !matA, %arg1: !matB, %arg2: !matC) -> !matC
+  attributes {
+    dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<
+      #dlti.dl_entry<"reg_blocks", [2, 32, 1]>
+  >>}
+{
+  %0 = linalg.generic {
+    indexing_maps = [affine_map<(m, n, k) -> (m, k, 1)>,
+                     affine_map<(m, n, k) -> (k, n, 1)>,
+                     affine_map<(m, n, k) -> (m, n)>],
+    iterator_types = ["parallel", "parallel", "reduction"]}
+    ins(%arg0, %arg1 : !matA, !matB)
+    outs(%arg2 : !matC) {
+  ^bb0(%in: f32, %in_1: f32, %out: f32):
+    %1 = arith.mulf %in, %in_1 : f32
+    %2 = arith.addf %out, %1 : f32
+    linalg.yield %2 : f32
+  } -> !matC
+  return %0 : !matC
+}
+
+// CHECK-LABEL: @negative_tile_non_projected_permutation
+// CHECK-NOT: scf.for
+// CHECK:     linalg.generic
+
+// -----
+
+!matA = tensor<256x512xf32>
+!matB = tensor<512x128xf32>
+!matC = tensor<256x128xf32>
+func.func @fuse_eltwise_consumer_and_initializator(
+  %arg0: !matA, %arg1: !matB, %bias: !matC) -> !matC
+  attributes {
+    dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<
+      #dlti.dl_entry<"reg_blocks", [2, 32, 1]>
+  >>}
+{
+  %c0 = arith.constant 0.0 : f32
+  %e = tensor.empty() : !matC
+  %acc = linalg.fill ins(%c0 : f32) outs(%e : !matC) -> !matC
+  %0 = linalg.matmul ins(%arg0, %arg1 : !matA, !matB)
+    outs(%acc : !matC) -> !matC
+  %1 = linalg.add ins(%0, %bias : !matC, !matC)
+    outs(%e : !matC) -> !matC
+  return %1 : !matC
+}
+
+// CHECK-LABEL: @fuse_eltwise_consumer_and_initializator
+// CHECK-COUNT-2: scf.for
+// CHECK: linalg.fill{{.*}}-> tensor<2x32xf32>
+// CHECK: scf.for
+// CHECK:   linalg.matmul{{.*}}-> tensor<2x32xf32>
+// CHECK:   scf.yield
+// CHECK: linalg.add{{.*}}-> tensor<2x32xf32>
+
+// -----
+
+!mat = tensor<256x256xf32>
+func.func @fuse_only_eltwise_consumers(
+  %arg0: !mat, %arg1: !mat, %arg2: !mat, %arg3: !mat) -> !mat
+  attributes {
+    dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<
+      #dlti.dl_entry<"reg_blocks", [2, 32, 1]>
+  >>}
+{
+  %e = tensor.empty() : !mat
+  %acc = linalg.sub ins(%arg0, %arg1 : !mat, !mat)
+    outs(%e : !mat) -> !mat
+  %0 = linalg.matmul ins(%arg0, %arg1 : !mat, !mat)
+    outs(%acc : !mat) -> !mat
+  %1 = linalg.add ins(%0, %arg3 : !mat, !mat)
+    outs(%e : !mat) -> !mat
+  %2 = linalg.matmul ins(%1, %arg1 : !mat, !mat)
+    outs(%arg2 : !mat) -> !mat
+  %3 = linalg.mul ins(%2, %arg3 : !mat, !mat)
+    outs(%e : !mat) -> !mat
+  return %3 : !mat
+}
+
+// CHECK-LABEL: @fuse_only_eltwise_consumers
+// Unfused eltwise producer
+// CHECK: linalg.sub{{.*}}-> tensor<256x256xf32>
+// Tiled and fused first matmul
+// CHECK-COUNT-2: scf.for
+// CHECK: scf.for
+// CHECK:   linalg.matmul{{.*}}-> tensor<2x32xf32>
+// CHECK:   scf.yield
+// CHECK: linalg.add{{.*}}-> tensor<2x32xf32>
+// Tiled and fused second matmul
+// CHECK-COUNT-2: scf.for
+// CHECK: scf.for
+// CHECK:   linalg.matmul{{.*}}-> tensor<2x32xf32>
+// CHECK:   scf.yield
+// CHECK: linalg.mul{{.*}}-> tensor<2x32xf32>
+
+// -----
+
+// Do not fuse consumers with multiple uses (even if it has only one user)
+// to avoid introducing recomputations.
+
+!matA = tensor<256x512xf32>
+!matB = tensor<512x128xf32>
+!matC = tensor<256x128xf32>
+func.func @negative_fuse_multi_use_consumer(
+  %arg0: !matA, %arg1: !matB, %arg2: !matC, %bias: !matC) -> !matC
+  attributes {
+    dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<
+      #dlti.dl_entry<"reg_blocks", [2, 32, 1]>
+  >>}
+{
+  %0 = linalg.matmul ins(%arg0, %arg1 : !matA, !matB)
+    outs(%arg2 : !matC) -> !matC
+  %1 = linalg.add ins(%0, %bias : !matC, !matC)
+    outs(%0 : !matC) -> !matC
+  return %1 : !matC
+}
+
+// CHECK-LABEL: @negative_fuse_multi_use_consumer
+// CHECK-COUNT-3: scf.for
+// CHECK:   linalg.matmul{{.*}}-> tensor<2x32xf32>
+// CHECK:   scf.yield
+// CHECK: linalg.add{{.*}}-> tensor<256x128xf32>
+
+// -----
+
+!matA = tensor<256x512xf32>
+!matB = tensor<512x128xf32>
+!matC = tensor<256x128xf32>
+!matD = tensor<128x256xf32>
+func.func @negative_fuse_transposed_consumer(
+  %arg0: !matA, %arg1: !matB, %arg2: !matC, %bias: !matC) -> !matD
+  attributes {
+    dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<
+      #dlti.dl_entry<"reg_blocks", [2, 32, 1]>
+  >>}
+{
+  %e = tensor.empty() : !matD
+  %0 = linalg.matmul ins(%arg0, %arg1 : !matA, !matB)
+    outs(%arg2 : !matC) -> !matC
+  %1 = linalg.generic {
+    indexing_maps = [affine_map<(m, n) -> (m, n)>,
+                     affine_map<(m, n) -> (m, n)>,
+                     affine_map<(m, n) -> (n, m)>], // transpose
+    iterator_types = ["parallel", "parallel"]}
+    ins(%0, %bias : !matC, !matC)
+    outs(%e : !matD) {
+  ^bb0(%in: f32, %in_1: f32, %out: f32):
+    %2 = arith.addf %in, %in_1 : f32
+    linalg.yield %2 : f32
+  } -> !matD
+  return %1 : !matD
+}
+
+// CHECK-LABEL: @negative_fuse_transposed_consumer
+// CHECK-COUNT-3: scf.for
+// CHECK:   linalg.matmul{{.*}}-> tensor<2x32xf32>
+// CHECK:   scf.yield
+// CHECK: linalg.generic{{.*}}outs({{.*}}: tensor<128x256xf32>)


### PR DESCRIPTION
Tile and fuse driver pass designed primarily for register blocking that is splitting linalg ops into smaller workloads (nanokernels) suitable for vectorization and further target-aware code generation.

The pass uses DLTI specification for tile size selection:
  `DLTI = "CPU"<"reg_blocks" = [bm,bn,bk]">`
Currently, the pass focuses on tiling contractions and greedily fusing their elementwise consumers.

Static shapes are required to allow for later vectorization. The tiling driver ensures that through loop peeling which results in up to two nanokernels per tiled dimensions when the tiles do not perfectly divide operands' shapes.