### PR TITLE
Vectorizer - vector drop unit dims

### DIFF
--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -664,4 +664,9 @@ def LinalgVectorize : Pass<"linalg-vectorize"> {
                            "arith::ArithDialect"];
 }
 
+def VectorDropUnitDims : Pass<"vector-drop-unit-dims"> {
+  let summary = "Drop unit dims from vector ops.";
+  let dependentDialects = ["vector::VectorDialect"];
+}
+
 #endif // TPP_DIALECT_TPP_PASSES

--- a/lib/TPP/Transforms/CMakeLists.txt
+++ b/lib/TPP/Transforms/CMakeLists.txt
@@ -34,6 +34,7 @@ add_mlir_library(TPPTransforms
   VectorContractToAMX.cpp
   RegisterBlocking.cpp
   LinalgVectorize.cpp
+  VectorDropUnitDims.cpp
 
   ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/TPP

--- a/lib/TPP/Transforms/VectorDropUnitDims.cpp
+++ b/lib/TPP/Transforms/VectorDropUnitDims.cpp
@@ -1,0 +1,48 @@
+//===- VectorDropUnitDims.cpp ------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Passes.h"
+
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+
+namespace mlir {
+namespace tpp {
+#define GEN_PASS_DEF_VECTORDROPUNITDIMS
+#include "TPP/Passes.h.inc"
+} // namespace tpp
+} // namespace mlir
+
+namespace {
+
+// A collection of patterns to drop unit dims and simplify vector ops.
+//
+// Removing unit dims helps to expose more canonical vector forms, cancel out
+// casts, and allows vector reads and writes to lower directly to LLVM ops
+// instead of SCF versions.
+struct VectorDropUnitDims
+    : public tpp::impl::VectorDropUnitDimsBase<VectorDropUnitDims> {
+  using VectorDropUnitDimsBase::VectorDropUnitDimsBase;
+
+  void runOnOperation() override {
+    auto *ctx = &getContext();
+
+    RewritePatternSet patterns(ctx);
+    vector::populateVectorToVectorCanonicalizationPatterns(patterns);
+    vector::populateCastAwayVectorLeadingOneDimPatterns(patterns);
+    vector::populateDropUnitDimWithShapeCastPatterns(patterns);
+
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+      return signalPassFailure();
+  }
+};
+} // namespace

--- a/test/Passes/vector-drop-unit-dims.mlir
+++ b/test/Passes/vector-drop-unit-dims.mlir
@@ -1,0 +1,69 @@
+// RUN: tpp-opt %s -vector-drop-unit-dims -split-input-file | FileCheck %s
+
+// Check a few relevant rewrites.
+// Core transforms are driven by upstream patterns.
+
+func.func @drop_unit_dims_read_write(
+    %arg0: tensor<512x128xf32>, %arg1: tensor<512x128xf32>,
+    %idx: index) -> tensor<512x128xf32> {
+  %c0 = arith.constant 0.0 : f32
+  %0 = vector.transfer_read %arg0[%idx, %idx], %c0
+    {in_bounds = [true, true]} : tensor<512x128xf32>, vector<1x64xf32>
+  %1 = vector.transfer_write %0, %arg1[%idx, %idx]
+    {in_bounds = [true, true]} : vector<1x64xf32>, tensor<512x128xf32>
+  return %1 : tensor<512x128xf32>
+}
+
+// CHECK-LABEL: @drop_unit_dims_read_write
+// CHECK: vector.transfer_read{{.*}}vector<64xf32>
+// CHECK: vector.transfer_write{{.*}}vector<64xf32>
+
+// -----
+
+func.func @fold_unit_dim_read_shape_cast(
+    %arg0: tensor<512x128xf32>, %idx: index
+    ) -> vector<64xf32> {
+  %c0 = arith.constant 0.0 : f32
+  %0 = vector.transfer_read %arg0[%idx, %idx], %c0
+    {in_bounds = [true, true]} : tensor<512x128xf32>, vector<1x1xf32>
+  %1 = vector.shape_cast %0 : vector<1x1xf32> to vector<1xf32>
+  %2 = vector.broadcast %1 : vector<1xf32> to vector<64xf32>
+  return %2 : vector<64xf32>
+}
+
+// CHECK-LABEL: @fold_unit_dim_read_shape_cast
+// CHECK: vector.transfer_read{{.*}}vector<1xf32>
+// CHECK-NOT: vector.shape_cast
+// CHECK: vector.broadcast
+
+// -----
+
+func.func @fold_unit_dim_shape_cast_insert_slice(
+    %arg0: vector<64xf32>, %arg1: vector<4x64xf32>
+    ) -> vector<4x64xf32> {
+  %0 = vector.shape_cast %arg0 : vector<64xf32> to vector<1x64xf32>
+  %1 = vector.insert_strided_slice %0, %arg1
+    {offsets = [0, 0], strides = [1, 1]}
+    : vector<1x64xf32> into vector<4x64xf32>
+  return %1 : vector<4x64xf32>
+}
+
+// CHECK-LABEL: @fold_unit_dim_shape_cast_insert_slice
+// CHECK-NOT: vector.shape_cast
+// CHECK: vector.insert_strided_slice
+
+// -----
+
+func.func @fold_unit_dims_eltwise(
+    %arg0 : vector<8xi32>, %arg1 : vector<1x8xi32>
+    ) -> vector<8xi32> {
+  %0 = vector.shape_cast %arg0 : vector<8xi32> to vector<1x8xi32>
+  %1 = arith.addi %0, %arg1 : vector<1x8xi32>
+  %2 = vector.shape_cast %1 : vector<1x8xi32> to vector<8xi32>
+  return %2 : vector<8xi32>
+}
+
+// CHECK-LABEL: @fold_unit_dims_eltwise
+// CHECK: vector.shape_cast{{.*}}to vector<8xi32>
+// CHECK: arith.addi{{.*}}vector<8xi32>
+// CHECK-NOT: vector.shape_cast


### PR DESCRIPTION
Collection of patterns to drop unit dims in vector ops.

Removing unit dims helps to expose more canonical vector forms, cancel out casts, and allows vector reads and writes to lower directly to LLVM ops instead of loops.