### PR TITLE
[μKernels]: vector-to-kernel pipeline changes + new .json files for bf16 type

### DIFF
--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -64,12 +64,19 @@
       "flags": [ "-n", "100" ],
       "extensions": [ "avx2" ]
     },
-    "gemm_bf16_dp2_mlir_vector_kernel_avx512bf16": {
+    "gemm_bf16_dp2_mlir_vector_kernel_avx512": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "avx512_bf16" ]
+      "extensions": [ "avx512.*" ]
+    },
+    "gemm_bf16_dp2_mlir_vector_kernel_avx2": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": {},
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=2,32,2'" ],
+      "extensions": [ "avx2" ]
     },
     "gemm_bf16_dp4_mlir": {
       "type": "IR-GEN",
@@ -113,12 +120,19 @@
       "flags": [ "-n", "100" ],
       "extensions": [ "avx2" ]
     },
-    "mlp_bf16_dp2_mlir_vector_kernel_avx512bf16": {
+    "mlp_bf16_dp2_mlir_vector_kernel_avx512": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "avx512_bf16" ]
+      "extensions": [ "avx512.*" ]
+    },
+    "mlp_bf16_dp2_mlir_vector_kernel_avx2": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": {},
+      "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --registerBlocking=2,32,2'" ],
+      "extensions": [ "avx2" ]
     },
     "mlp_bf16_dp4_mlir": {
       "type": "IR-GEN",
@@ -165,12 +179,19 @@
       "flags": [ "-n", "100"],
       "extensions": [ "(avx2|asimd)" ]
     },
-    "bf16_3x1024_const_mlir_vector_kernel_avx512bf16": {
+    "bf16_3x1024_const_mlir_vector_kernel_avx512": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'"],
-      "extensions": [ "avx512_bf16" ]
+      "extensions": [ "avx512.*" ]
+    },
+    "bf16_3x1024_const_mlir_vector_kernel_avx2": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": {},
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=2,32,2'"],
+      "extensions": [ "avx2" ]
     },
     "bf16_3x1024_args_mlir": {
       "type": "IR-GEN",
@@ -179,12 +200,19 @@
       "flags": [ "-n", "100"],
       "extensions": [ "(avx2|asimd)" ]
     },
-    "bf16_3x1024_args_mlir_vector_kernel_avx512bf16": {
+    "bf16_3x1024_args_mlir_vector_kernel_avx512": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'"],
-      "extensions": [ "avx512_bf16" ]
+      "extensions": [ "avx512.*" ]
+    },
+    "bf16_3x1024_args_mlir_vector_kernel_avx2": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": {},
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=2,32,2'"],
+      "extensions": [ "avx2" ]
     }
   }},
   {
@@ -224,12 +252,19 @@
       "flags": [ "-n", "100"],
       "extensions": [ "(avx2|asimd)" ]
     },
-    "bf16_3x1024_const_mlir_vector_kernel_avx512bf16": {
+    "bf16_3x1024_const_mlir_vector_kernel_avx512": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'"],
-      "extensions": [ "avx512_bf16" ]
+      "extensions": [ "avx512.*" ]
+    },
+    "bf16_3x1024_const_mlir_vector_kernel_avx2": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": {},
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=2,32,2'"],
+      "extensions": [ "avx2" ]
     },
     "bf16_3x1024_args_mlir": {
       "type": "IR-GEN",
@@ -238,12 +273,19 @@
       "flags": [ "-n", "100"],
       "extensions": [ "(avx2|asimd)" ]
     },
-    "bf16_3x1024_args_mlir_vector_kernel_avx512bf16": {
+    "bf16_3x1024_args_mlir_vector_kernel_avx512": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'"],
-      "extensions": [ "avx512_bf16" ]
+      "extensions": [ "avx512.*" ]
+    },
+    "bf16_3x1024_args_mlir_vector_kernel_avx2": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": {},
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=2,32,2'"],
+      "extensions": [ "avx2" ]
     }
   }}
 ]

--- a/benchmarks/config/omp/mlir-bf16.json
+++ b/benchmarks/config/omp/mlir-bf16.json
@@ -31,34 +31,65 @@
     }
   }},
   {
-  "gemm_bf16_dp2_mlir_vector_kernel_avx512bf16": {
+  "gemm_bf16_dp2_mlir_vector_kernel_avx512": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "avx512_bf16" ]
+      "extensions": [ "(avx512.*)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "avx512_bf16" ]
+      "extensions": [ "(avx512.*)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "avx512_bf16" ]
+      "extensions": [ "(avx512.*)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "avx512_bf16" ]
+      "extensions": [ "(avx512.*)" ]
+    }
+  }},
+  {
+  "gemm_bf16_dp2_mlir_vector_kernel_avx2": {
+    "bf16_dp2_3x1024_omp_2_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=2,32,2'" ],
+      "extensions": [ "(avx2)" ]
+    },
+    "bf16_dp2_3x1024_omp_4_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=2,32,2'" ],
+      "extensions": [ "(avx2)" ]
+    },
+    "bf16_dp2_3x1024_omp_8_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=2,32,2'" ],
+      "extensions": [ "(avx2)" ]
+    },
+    "bf16_dp2_3x1024_omp_16_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=2,32,2'" ],
+      "extensions": [ "(avx2)" ]
     }
   }},
   {
@@ -93,34 +124,65 @@
     }
   }},
   {
-  "mlp_bf16_dp2_mlir_vector_kernel_avx512bf16": {
+  "mlp_bf16_dp2_mlir_vector_kernel_avx512": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "avx512_bf16" ]
+      "extensions": [ "(avx512.*)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "avx512_bf16" ]
+      "extensions": [ "(avx512.*)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "avx512_bf16" ]
+      "extensions": [ "(avx512.*)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
-      "extensions": [ "avx512_bf16" ]
+      "extensions": [ "(avx512.*)" ]
+    }
+  }},
+  {
+  "mlp_bf16_dp2_mlir_vector_kernel_avx2": {
+    "bf16_dp2_3x1024_omp_2_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=2,32,2'" ],
+      "extensions": [ "(avx2)" ]
+    },
+    "bf16_dp2_3x1024_omp_4_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=2,32,2'" ],
+      "extensions": [ "(avx2)" ]
+    },
+    "bf16_dp2_3x1024_omp_8_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=2,32,2'" ],
+      "extensions": [ "(avx2)" ]
+    },
+    "bf16_dp2_3x1024_omp_16_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=2,32,2'" ],
+      "extensions": [ "(avx2)" ]
     }
   }},
   {

--- a/lib/TPP/PassBundles/VectorToKernel.cpp
+++ b/lib/TPP/PassBundles/VectorToKernel.cpp
@@ -53,17 +53,14 @@ struct VectorToKernel : public tpp::impl::VectorToKernelBase<VectorToKernel>,
 private:
   void constructPipeline() override {
     // TODO: Pass ordering based on target architecture starting from AMX ->
-    // avx512 -> avx2 to subset needs to be improved by moving out some logic of
-    // Bf16DotProduct related to iterarg creation and let hoistvectorTransfer
-    // pass address it.
-    pm.addNestedPass<func::FuncOp>(createBF16DotProduct());
+    // avx512 -> avx2 to subset needs to be improved by updating the `k`
+    // tile size check for AMX lowering. With k = 1 (or vnni size) AMX fails
+    // lowering to micro-kernels on EMR. Bf16DotProduct tests with k = 1 
+    // and those tests gets lowered by AMX pass on EMR machine.
     pm.addNestedPass<func::FuncOp>(createHoistVectorTransfers());
+     pm.addNestedPass<func::FuncOp>(createMicroKernels());
     if (vnni::utils::hasAMX())
       pm.addNestedPass<func::FuncOp>(createVectorContractToAMX());
     pm.addNestedPass<func::FuncOp>(createMicroKernels());
-    pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-    VectorContractToFMAOptions options;
-    options.targetFeature = vecBundleCpuTargetFeature;
-    pm.addNestedPass<func::FuncOp>(createVectorContractToFMA(options));
   }
 };


### PR DESCRIPTION
This PR cleans-up the `vector-to-kernel` pipeline and add new .json file for `bf16` benchmarking.