### PR TITLE
[μKernels]: lowering based on m and n tile size

### DIFF
--- a/lib/TPP/Transforms/VectorContractToMicroKernels.cpp
+++ b/lib/TPP/Transforms/VectorContractToMicroKernels.cpp
@@ -412,6 +412,10 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
     // matrix then broadcast A ony-by-one + FMA.
     // If N > M: perform opposite. Broadcast A matrix then load B one-by-
     // one + FMA.
+    // Following this kind of lowering, we reduce the register loads by 
+    // stacking the less B loads or less A broadcasts and do the larger B 
+    // loads or A broadcast in a LIFO manner. Finally, it helps in reducing
+    // the probablity of register spills.
     bool mDriven = true;
     int64_t nBlock = N / sizeFactor;
 

--- a/lib/TPP/Transforms/VectorContractToMicroKernels.cpp
+++ b/lib/TPP/Transforms/VectorContractToMicroKernels.cpp
@@ -265,14 +265,13 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
     // Retrive the element type (f32 or bf16 or f16)
     auto subviewOpAcc =
         vectorReadOpAcc.getOperand(0).getDefiningOp<memref::SubViewOp>();
-    auto subviewOpLhs = 
-	vectorReadOpLhs.getOperand(0).getDefiningOp<memref::SubViewOp>();
-
+    auto subviewOpLhs =
+        vectorReadOpLhs.getOperand(0).getDefiningOp<memref::SubViewOp>();
 
     auto elementType =
         (cast<MemRefType>(subviewOpLhs.getType())).getElementType();
-    auto outsElementType=
-	(cast<MemRefType>(subviewOpAcc.getType())).getElementType();
+    auto outsElementType =
+        (cast<MemRefType>(subviewOpAcc.getType())).getElementType();
 
     // We get target architecture and decide on uKernel lowering using flags
     bool avx512 = vnni::utils::hasAVX512();
@@ -409,15 +408,15 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
       return rewriter.notifyMatchFailure(
           contractOp, "Affine map permutation not supported.");
 
-    // Lowering is done based on M and N tile sizes. If M >= N: load all B 
+    // Lowering is done based on M and N tile sizes. If M >= N: load all B
     // matrix then broadcast A ony-by-one + FMA.
     // If N > M: perform opposite. Broadcast A matrix then load B one-by-
-    // one + FMA. 
+    // one + FMA.
     bool mDriven = true;
-    int64_t nBlock = N/sizeFactor;
+    int64_t nBlock = N / sizeFactor;
 
     if (nBlock > M)
-            mDriven = false;
+      mDriven = false;
 
     rewriter.setInsertionPoint(mForOp);
     auto i32Type = rewriter.getIntegerType(32);
@@ -446,8 +445,9 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
           Value indexOp_B = rewriter.create<arith::ConstantIndexOp>(
               reductionForOp.getLoc(), j);
           auto valueCRow = rewriter.create<vector::LoadOp>(
-              reductionForOp.getLoc(), VectorType::get(sizeFactor, outsElementType),
-              subviewOpAcc, ValueRange{indexOp_A, indexOp_B});
+              reductionForOp.getLoc(),
+              VectorType::get(sizeFactor, outsElementType), subviewOpAcc,
+              ValueRange{indexOp_A, indexOp_B});
           auto bitcast_i16 = rewriter.create<vector::BitCastOp>(
               reductionForOp.getLoc(), VectorType::get(sizeFactor, i16Type),
               valueCRow);
@@ -475,8 +475,9 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
           Value indexOp_B = rewriter.create<arith::ConstantIndexOp>(
               reductionForOp.getLoc(), j);
           auto valueCRow = rewriter.create<vector::LoadOp>(
-              reductionForOp.getLoc(), VectorType::get(sizeFactor, outsElementType),
-              subviewOpAcc, ValueRange{indexOp_A, indexOp_B});
+              reductionForOp.getLoc(),
+              VectorType::get(sizeFactor, outsElementType), subviewOpAcc,
+              ValueRange{indexOp_A, indexOp_B});
           auto f32CVector = rewriter.create<arith::ExtFOp>(
               reductionForOp.getLoc(),
               VectorType::get({8}, rewriter.getF32Type()),
@@ -494,8 +495,9 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
           Value indexOp_B = rewriter.create<arith::ConstantIndexOp>(
               reductionForOp.getLoc(), j);
           auto valueCRow = rewriter.create<vector::LoadOp>(
-              reductionForOp.getLoc(), VectorType::get(sizeFactor, outsElementType),
-              subviewOpAcc, ValueRange{indexOp_A, indexOp_B});
+              reductionForOp.getLoc(),
+              VectorType::get(sizeFactor, outsElementType), subviewOpAcc,
+              ValueRange{indexOp_A, indexOp_B});
           loopItrArgs.push_back(valueCRow);
         }
       }
@@ -569,7 +571,7 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
                     rewriter.getIndexAttr(1), rewriter.getIndexAttr(1),
                     rewriter.getIndexAttr(1), rewriter.getIndexAttr(1)};
 
-                // uKernel lowering for f32 type. M -> N. 
+                // uKernel lowering for f32 type. M -> N.
                 if (isF32 && mDriven) {
                   // Load elements of B matrix and store in a DS
                   for (int j = 0; j < N; j = j + sizeFactor) {
@@ -660,103 +662,106 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
                 // cpx (zen5) to target avx512bf16dp.
                 if (bf16dp && isBF16) {
 
+                  if (mDriven) { // M -> N
+                    // Load elements of B matrix and store in a DS
+                    for (int j = 0; j < N; j = j + sizeFactor) {
+                      Value indexOp_j = rewriter.create<arith::ConstantIndexOp>(
+                          reductionForOp.getLoc(), j);
+                      auto valueRow = rewriterNewKForOp.create<vector::LoadOp>(
+                          kForOp.getLoc(), VectorType::get(32, elementType),
+                          rhsClone->getResult(0),
+                          ValueRange{indexOp_c0, indexOp_c0, indexOp_j,
+                                     indexOp_c0});
+                      matf32.push_back(valueRow);
+                    }
 
-		  if (mDriven) { // M -> N
-                  // Load elements of B matrix and store in a DS
-                  for (int j = 0; j < N; j = j + sizeFactor) {
-                    Value indexOp_j = rewriter.create<arith::ConstantIndexOp>(
-                        reductionForOp.getLoc(), j);
-                    auto valueRow = rewriterNewKForOp.create<vector::LoadOp>(
-                        kForOp.getLoc(), VectorType::get(32, elementType),
-                        rhsClone->getResult(0),
-                        ValueRange{indexOp_c0, indexOp_c0, indexOp_j,
-                                   indexOp_c0});
-                    matf32.push_back(valueRow);
-                  }
+                    // Load elements of A matrix, do FMA, and store in a DS
+                    for (int i = 0; i < M; i++) {
+                      Value indexOp_i = rewriter.create<arith::ConstantIndexOp>(
+                          reductionForOp.getLoc(), i);
+                      auto valueRow = rewriterNewKForOp.create<vector::LoadOp>(
+                          kForOp.getLoc(), VectorType::get({vnni}, elementType),
+                          lhsClone->getResult(0),
+                          ValueRange{indexOp_c0, indexOp_i, indexOp_c0,
+                                     indexOp_c0});
+                      auto bitcastValue_i32 =
+                          rewriterNewKForOp.create<vector::BitCastOp>(
+                              kForOp.getLoc(), VectorType::get({1}, i32Type),
+                              valueRow);
+                      auto bcst_i32 =
+                          rewriterNewKForOp.create<vector::BroadcastOp>(
+                              kForOp.getLoc(),
+                              VectorType::get(sizeFactor, i32Type),
+                              bitcastValue_i32);
+                      auto valuef32 =
+                          rewriterNewKForOp.create<vector::BitCastOp>(
+                              kForOp.getLoc(),
+                              VectorType::get(32,
+                                              rewriterNewKForOp.getBF16Type()),
+                              bcst_i32);
+                      for (int j = 0; j < (N / sizeFactor); j++) {
+                        auto dp = rewriter.create<mlir::x86vector::DotBF16Op>(
+                            kForOp.getLoc(), dstType,
+                            iterArgsNewKForOp[i + (j * M)], valuef32,
+                            matf32[j]);
+                        oddFMAs.push_back(dp);
+                      }
+                    }
 
-                  // Load elements of A matrix, do FMA, and store in a DS
-                  for (int i = 0; i < M; i++) { 
-                    Value indexOp_i = rewriter.create<arith::ConstantIndexOp>(
-                        reductionForOp.getLoc(), i);
-                    auto valueRow = rewriterNewKForOp.create<vector::LoadOp>(
-                        kForOp.getLoc(), VectorType::get({vnni}, elementType),
-                        lhsClone->getResult(0),
-                        ValueRange{indexOp_c0, indexOp_i, indexOp_c0,
-                                   indexOp_c0});
-                    auto bitcastValue_i32 =
-                        rewriterNewKForOp.create<vector::BitCastOp>(
-                        kForOp.getLoc(), VectorType::get({1},
-                        i32Type), valueRow);
-                    auto bcst_i32 =
-                        rewriterNewKForOp.create<vector::BroadcastOp>(
-                            kForOp.getLoc(), VectorType::get(sizeFactor,
-                            i32Type), bitcastValue_i32);
-                    auto valuef32 = rewriterNewKForOp.create<vector::BitCastOp>(
-                        kForOp.getLoc(),
-                        VectorType::get(32, rewriterNewKForOp.getBF16Type()),
-                        bcst_i32);
+                    // Re-arrange the stored FMAs in order of N -> M.
+                    // We load C matrix with N -> M. For example: c[0][0],
+                    // c[1][0] We do dp as M -> N order { [0][0], [0][16] ...}.
+                    // So, shuffling the M -> N to N -> M order
                     for (int j = 0; j < (N / sizeFactor); j++) {
-                      auto dp = rewriter.create<mlir::x86vector::DotBF16Op>(
-                          kForOp.getLoc(), dstType,
-                          iterArgsNewKForOp[i + (j * M)], valuef32, matf32[j]);
-                      oddFMAs.push_back(dp);
+                      for (int i = 0; i < M; i++) {
+                        evenFMAs.push_back(oddFMAs[j + (i * (N / sizeFactor))]);
+                      }
                     }
-                  }
 
-                  // Re-arrange the stored FMAs in order of N -> M.
-                  // We load C matrix with N -> M. For example: c[0][0], c[1][0]
-                  // We do dp as M -> N order { [0][0], [0][16] ...}. So,
-                  // shuffling the M -> N to N -> M order
-                  for (int j = 0; j < (N / sizeFactor); j++) {
+                  } else { // N -> M
                     for (int i = 0; i < M; i++) {
-                      evenFMAs.push_back(oddFMAs[j + (i * (N / sizeFactor))]);
+                      Value indexOp_i = rewriter.create<arith::ConstantIndexOp>(
+                          reductionForOp.getLoc(), i);
+                      auto valueRow = rewriterNewKForOp.create<vector::LoadOp>(
+                          kForOp.getLoc(), VectorType::get({vnni}, elementType),
+                          lhsClone->getResult(0),
+                          ValueRange{indexOp_c0, indexOp_i, indexOp_c0,
+                                     indexOp_c0});
+                      auto bitcastValue_i32 =
+                          rewriterNewKForOp.create<vector::BitCastOp>(
+                              kForOp.getLoc(), VectorType::get({1}, i32Type),
+                              valueRow);
+                      auto bcst_i32 =
+                          rewriterNewKForOp.create<vector::BroadcastOp>(
+                              kForOp.getLoc(),
+                              VectorType::get(sizeFactor, i32Type),
+                              bitcastValue_i32);
+                      auto valuef32 =
+                          rewriterNewKForOp.create<vector::BitCastOp>(
+                              kForOp.getLoc(),
+                              VectorType::get(32,
+                                              rewriterNewKForOp.getBF16Type()),
+                              bcst_i32);
+                      matf32.push_back(valuef32);
+                    }
+
+                    for (int j = 0, k = 0; j < N; j = j + sizeFactor) {
+                      Value indexOp_j = rewriter.create<arith::ConstantIndexOp>(
+                          reductionForOp.getLoc(), j);
+                      auto valueRow = rewriterNewKForOp.create<vector::LoadOp>(
+                          kForOp.getLoc(), VectorType::get(32, elementType),
+                          rhsClone->getResult(0),
+                          ValueRange{indexOp_c0, indexOp_c0, indexOp_j,
+                                     indexOp_c0});
+                      for (int i = 0; i < M; i++) {
+                        auto dp = rewriter.create<mlir::x86vector::DotBF16Op>(
+                            kForOp.getLoc(), dstType, iterArgsNewKForOp[k],
+                            matf32[i], valueRow);
+                        k++;
+                        evenFMAs.push_back(dp);
+                      }
                     }
                   }
-
-		  } else {  // N -> M
-		    for (int i = 0; i < M; i++) {
-                    Value indexOp_i = rewriter.create<arith::ConstantIndexOp>(
-                        reductionForOp.getLoc(), i);
-                    auto valueRow = rewriterNewKForOp.create<vector::LoadOp>(
-                        kForOp.getLoc(), VectorType::get({vnni}, elementType),
-                        lhsClone->getResult(0),
-                        ValueRange{indexOp_c0, indexOp_i, indexOp_c0,
-                                   indexOp_c0});
-                    auto bitcastValue_i32 =
-                        rewriterNewKForOp.create<vector::BitCastOp>(
-                            kForOp.getLoc(),
-                            VectorType::get({1}, i32Type), valueRow);
-                    auto bcst_i32 =
-                        rewriterNewKForOp.create<vector::BroadcastOp>(
-                            kForOp.getLoc(),
-                            VectorType::get(sizeFactor, i32Type),
-                            bitcastValue_i32);
-                    auto valuef32 = rewriterNewKForOp.create<vector::BitCastOp>(
-                        kForOp.getLoc(),
-                        VectorType::get(32, rewriterNewKForOp.getBF16Type()),
-                        bcst_i32);
-                    matf32.push_back(valuef32);
-                  }
-
-		   for (int j = 0, k = 0; j < N; j = j + sizeFactor) {
-                    Value indexOp_j = rewriter.create<arith::ConstantIndexOp>(
-                        reductionForOp.getLoc(), j);
-                    auto valueRow = rewriterNewKForOp.create<vector::LoadOp>(
-                        kForOp.getLoc(), VectorType::get(32, elementType),
-                        rhsClone->getResult(0),
-                        ValueRange{indexOp_c0, indexOp_c0, indexOp_j,
-                                   indexOp_c0});
-                    for (int i = 0; i < M; i++) {
-                      auto dp = rewriter.create<mlir::x86vector::DotBF16Op>(
-                          kForOp.getLoc(), dstType,
-                          iterArgsNewKForOp[k], matf32[i], valueRow);
-                      k++;
-                      evenFMAs.push_back(dp);
-                    }
-                  }
-
-
-		  }
                 }
 
                 // bf16 type + fallback + avx512. uKernel lowering for machines
@@ -894,8 +899,8 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
                 // uKernel lowering for AVX2  machines
                 // Target: (a) f16 and bf16 for srf kind of machines
                 // (b) bf16 fallback + avx2 instructions.
-		// TODO: update lowering based on M & N. Now it is
-		// default to M -> N
+                // TODO: update lowering based on M & N. Now it is
+                // default to M -> N
                 if (srf || (fallback && avx2 && !avx512)) {
                   // Load odd elements of A Matrix and store in a DS
                   for (int i = 0; i < M; i++) {

--- a/lib/TPP/Transforms/VectorContractToMicroKernels.cpp
+++ b/lib/TPP/Transforms/VectorContractToMicroKernels.cpp
@@ -409,6 +409,16 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
       return rewriter.notifyMatchFailure(
           contractOp, "Affine map permutation not supported.");
 
+    // Lowering is done based on M and N tile sizes. If M >= N: load all B 
+    // matrix then broadcast A ony-by-one + FMA.
+    // If N > M: perform opposite. Broadcast A matrix then load B one-by-
+    // one + FMA. 
+    bool mDriven = true;
+    int64_t nBlock = N/sizeFactor;
+
+    if (nBlock > M)
+            mDriven = false;
+
     rewriter.setInsertionPoint(mForOp);
     auto i32Type = rewriter.getIntegerType(32);
     auto i16Type = rewriter.getIntegerType(16);
@@ -559,8 +569,8 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
                     rewriter.getIndexAttr(1), rewriter.getIndexAttr(1),
                     rewriter.getIndexAttr(1), rewriter.getIndexAttr(1)};
 
-                // uKernel lowering for f32 type. Target: avx512 instructions
-                if (isF32 && avx512) {
+                // uKernel lowering for f32 type. M -> N. 
+                if (isF32 && mDriven) {
                   // Load elements of B matrix and store in a DS
                   for (int j = 0; j < N; j = j + sizeFactor) {
                     Value indexOp_j = rewriter.create<arith::ConstantIndexOp>(
@@ -606,8 +616,7 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
                       evenFMAs.push_back(oddFMAs[j + (i * (N / sizeFactor))]);
                     }
                   }
-                } else if (isF32 && avx2) { // uKernel lowering for f32 type.
-                                            // Target: avx2 instructions
+                } else if (isF32 && !mDriven) { // N -> M.
                   // Load elements of A matrix and store in a DS
                   for (int i = 0; i < M; i++) {
                     Value indexOp_i = rewriter.create<arith::ConstantIndexOp>(
@@ -650,6 +659,9 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
                 // bf16 type + avx512. uKernel lowering for machines like
                 // cpx (zen5) to target avx512bf16dp.
                 if (bf16dp && isBF16) {
+
+
+		  if (mDriven) { // M -> N
                   // Load elements of B matrix and store in a DS
                   for (int j = 0; j < N; j = j + sizeFactor) {
                     Value indexOp_j = rewriter.create<arith::ConstantIndexOp>(
@@ -663,7 +675,7 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
                   }
 
                   // Load elements of A matrix, do FMA, and store in a DS
-                  for (int i = 0; i < M; i++) {
+                  for (int i = 0; i < M; i++) { 
                     Value indexOp_i = rewriter.create<arith::ConstantIndexOp>(
                         reductionForOp.getLoc(), i);
                     auto valueRow = rewriterNewKForOp.create<vector::LoadOp>(
@@ -673,16 +685,12 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
                                    indexOp_c0});
                     auto bitcastValue_i32 =
                         rewriterNewKForOp.create<vector::BitCastOp>(
-                            kForOp.getLoc(),
-                            VectorType::get({1},
-                                            rewriterNewKForOp.getI32Type()),
-                            valueRow);
+                        kForOp.getLoc(), VectorType::get({1},
+                        i32Type), valueRow);
                     auto bcst_i32 =
                         rewriterNewKForOp.create<vector::BroadcastOp>(
-                            kForOp.getLoc(),
-                            VectorType::get(sizeFactor,
-                                            rewriterNewKForOp.getI32Type()),
-                            bitcastValue_i32);
+                            kForOp.getLoc(), VectorType::get(sizeFactor,
+                            i32Type), bitcastValue_i32);
                     auto valuef32 = rewriterNewKForOp.create<vector::BitCastOp>(
                         kForOp.getLoc(),
                         VectorType::get(32, rewriterNewKForOp.getBF16Type()),
@@ -704,6 +712,51 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
                       evenFMAs.push_back(oddFMAs[j + (i * (N / sizeFactor))]);
                     }
                   }
+
+		  } else {  // N -> M
+		    for (int i = 0; i < M; i++) {
+                    Value indexOp_i = rewriter.create<arith::ConstantIndexOp>(
+                        reductionForOp.getLoc(), i);
+                    auto valueRow = rewriterNewKForOp.create<vector::LoadOp>(
+                        kForOp.getLoc(), VectorType::get({vnni}, elementType),
+                        lhsClone->getResult(0),
+                        ValueRange{indexOp_c0, indexOp_i, indexOp_c0,
+                                   indexOp_c0});
+                    auto bitcastValue_i32 =
+                        rewriterNewKForOp.create<vector::BitCastOp>(
+                            kForOp.getLoc(),
+                            VectorType::get({1}, i32Type), valueRow);
+                    auto bcst_i32 =
+                        rewriterNewKForOp.create<vector::BroadcastOp>(
+                            kForOp.getLoc(),
+                            VectorType::get(sizeFactor, i32Type),
+                            bitcastValue_i32);
+                    auto valuef32 = rewriterNewKForOp.create<vector::BitCastOp>(
+                        kForOp.getLoc(),
+                        VectorType::get(32, rewriterNewKForOp.getBF16Type()),
+                        bcst_i32);
+                    matf32.push_back(valuef32);
+                  }
+
+		   for (int j = 0, k = 0; j < N; j = j + sizeFactor) {
+                    Value indexOp_j = rewriter.create<arith::ConstantIndexOp>(
+                        reductionForOp.getLoc(), j);
+                    auto valueRow = rewriterNewKForOp.create<vector::LoadOp>(
+                        kForOp.getLoc(), VectorType::get(32, elementType),
+                        rhsClone->getResult(0),
+                        ValueRange{indexOp_c0, indexOp_c0, indexOp_j,
+                                   indexOp_c0});
+                    for (int i = 0; i < M; i++) {
+                      auto dp = rewriter.create<mlir::x86vector::DotBF16Op>(
+                          kForOp.getLoc(), dstType,
+                          iterArgsNewKForOp[k], matf32[i], valueRow);
+                      k++;
+                      evenFMAs.push_back(dp);
+                    }
+                  }
+
+
+		  }
                 }
 
                 // bf16 type + fallback + avx512. uKernel lowering for machines
@@ -840,7 +893,9 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
 
                 // uKernel lowering for AVX2  machines
                 // Target: (a) f16 and bf16 for srf kind of machines
-                // (b) bf16 fallback + avx2 instructions
+                // (b) bf16 fallback + avx2 instructions.
+		// TODO: update lowering based on M & N. Now it is
+		// default to M -> N
                 if (srf || (fallback && avx2 && !avx512)) {
                   // Load odd elements of A Matrix and store in a DS
                   for (int i = 0; i < M; i++) {

--- a/test/Passes/uKernels/avx2/pass-vector-contract-to-FMAs.mlir
+++ b/test/Passes/uKernels/avx2/pass-vector-contract-to-FMAs.mlir
@@ -54,6 +54,63 @@ module {
 
 // -----
 
+#map_nm = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map_nm1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map_nm2 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+module {
+  func.func @opt_register_4x3(%arg0: memref<1x4x32xf32>, %arg1: memref<1x32x24xf32>, %arg2: memref<4x24xf32>) -> memref<4x24xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c24 = arith.constant 24 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    scf.for %arg3 = %c0 to %c4 step %c4 {
+      scf.for %arg4 = %c0 to %c24 step %c24 {
+        %subview = memref.subview %arg2[%arg3, %arg4] [4, 24] [1, 1] : memref<4x24xf32> to memref<4x24xf32, strided<[24, 1], offset: ?>>
+        %0 = vector.transfer_read %subview[%c0, %c0], %cst {in_bounds = [true, true]} : memref<4x24xf32, strided<[24, 1], offset: ?>>, vector<4x24xf32>
+        %1 = scf.for %arg5 = %c0 to %c1 step %c1 iter_args(%arg6 = %0) -> (vector<4x24xf32>) {
+          %2 = scf.for %arg7 = %c0 to %c32 step %c1 iter_args(%arg8 = %arg6) -> (vector<4x24xf32>) {
+            %subview_0 = memref.subview %arg0[%arg5, %arg3, %arg7] [1, 4, 1] [1, 1, 1] : memref<1x4x32xf32> to memref<1x4x1xf32, strided<[128, 32, 1], offset: ?>>
+            %subview_1 = memref.subview %arg1[%arg5, %arg7, %arg4] [1, 1, 24] [1, 1, 1] : memref<1x32x24xf32> to memref<1x1x24xf32, strided<[768, 24, 1], offset: ?>>
+            %3 = vector.transfer_read %subview_0[%c0, %c0, %c0], %cst {in_bounds = [true, true, true]} : memref<1x4x1xf32, strided<[128, 32, 1], offset: ?>>, vector<1x4x1xf32>
+            %4 = vector.transfer_read %subview_1[%c0, %c0, %c0], %cst {in_bounds = [true, true, true]} : memref<1x1x24xf32, strided<[768, 24, 1], offset: ?>>, vector<1x1x24xf32>
+            %5 = vector.contract {indexing_maps = [#map_nm, #map_nm1, #map_nm2], iterator_types = ["reduction", "parallel", "parallel", "reduction"], kind = #vector.kind<add>} %3, %4, %arg8 : vector<1x4x1xf32>, vector<1x1x24xf32> into vector<4x24xf32>
+            scf.yield %5 : vector<4x24xf32>
+          }
+          scf.yield %2 : vector<4x24xf32>
+        }
+        vector.transfer_write %1, %subview[%c0, %c0] {in_bounds = [true, true]} : vector<4x24xf32>, memref<4x24xf32, strided<[24, 1], offset: ?>>
+      }
+    }
+    return %arg2 : memref<4x24xf32>
+  }
+}
+
+// CHECK-LABEL:   func.func @opt_register_4x3
+// CHECK: scf.for
+// CHECK: vector.broadcast
+// CHECK-NEXT: vector.fma{{.*}}vector<8xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<8xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<8xf32>
+// CHECK-NEXT: vector.load
+// CHECK-NEXT: vector.broadcast
+// CHECK-NEXT: vector.fma{{.*}}vector<8xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<8xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<8xf32>
+// CHECK-NEXT: vector.load
+// CHECK-NEXT: vector.broadcast
+// CHECK-NEXT: vector.fma{{.*}}vector<8xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<8xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<8xf32>
+// CHECK-NEXT: vector.load
+// CHECK-NEXT: vector.broadcast
+// CHECK-NEXT: vector.fma{{.*}}vector<8xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<8xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<8xf32>
+
+// -----
+
 #no_map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
 #no_map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
 #no_map2 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>

--- a/test/Passes/uKernels/avx512/pass-vector-contract-to-FMAs.mlir
+++ b/test/Passes/uKernels/avx512/pass-vector-contract-to-FMAs.mlir
@@ -73,3 +73,75 @@ module {
 
 // -----
 
+#map_nm = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map_nm1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map_nm2 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+module {
+  func.func @opt_register_4x6(%arg0: memref<1x4x32xf32>, %arg1: memref<1x32x96xf32>, %arg2: memref<4x96xf32>) -> memref<4x96xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c96 = arith.constant 96 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    scf.for %arg3 = %c0 to %c4 step %c4 {
+      scf.for %arg4 = %c0 to %c96 step %c96 {
+        %subview = memref.subview %arg2[%arg3, %arg4] [4, 96] [1, 1] : memref<4x96xf32> to memref<4x96xf32, strided<[96, 1], offset: ?>>
+        %0 = vector.transfer_read %subview[%c0, %c0], %cst {in_bounds = [true, true]} : memref<4x96xf32, strided<[96, 1], offset: ?>>, vector<4x96xf32>
+        %1 = scf.for %arg5 = %c0 to %c1 step %c1 iter_args(%arg6 = %0) -> (vector<4x96xf32>) {
+          %2 = scf.for %arg7 = %c0 to %c32 step %c1 iter_args(%arg8 = %arg6) -> (vector<4x96xf32>) {
+            %subview_0 = memref.subview %arg0[%arg5, %arg3, %arg7] [1, 4, 1] [1, 1, 1] : memref<1x4x32xf32> to memref<1x4x1xf32, strided<[128, 32, 1], offset: ?>>
+            %subview_1 = memref.subview %arg1[%arg5, %arg7, %arg4] [1, 1, 96] [1, 1, 1] : memref<1x32x96xf32> to memref<1x1x96xf32, strided<[3072, 96, 1], offset: ?>>
+            %3 = vector.transfer_read %subview_0[%c0, %c0, %c0], %cst {in_bounds = [true, true, true]} : memref<1x4x1xf32, strided<[128, 32, 1], offset: ?>>, vector<1x4x1xf32>
+            %4 = vector.transfer_read %subview_1[%c0, %c0, %c0], %cst {in_bounds = [true, true, true]} : memref<1x1x96xf32, strided<[3072, 96, 1], offset: ?>>, vector<1x1x96xf32>
+            %5 = vector.contract {indexing_maps = [#map_nm, #map_nm1, #map_nm2], iterator_types = ["reduction", "parallel", "parallel", "reduction"], kind = #vector.kind<add>} %3, %4, %arg8 : vector<1x4x1xf32>, vector<1x1x96xf32> into vector<4x96xf32>
+            scf.yield %5 : vector<4x96xf32>
+          }
+          scf.yield %2 : vector<4x96xf32>
+        }
+        vector.transfer_write %1, %subview[%c0, %c0] {in_bounds = [true, true]} : vector<4x96xf32>, memref<4x96xf32, strided<[96, 1], offset: ?>>
+      }
+    }
+    return %arg2 : memref<4x96xf32>
+  }
+}
+
+// CHECK-LABEL:   func.func @opt_register_4x6
+// CHECK: scf.for
+// CHECK: vector.broadcast
+// CHECK-NEXT: vector.load
+// CHECK-NEXT: vector.broadcast
+// CHECK-NEXT: vector.load
+// CHECK-NEXT: vector.broadcast
+// CHECK-NEXT: vector.load
+// CHECK-NEXT: vector.broadcast
+// CHECK-NEXT: vector.load
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.load
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.load
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.load
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.load
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.load
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<16xf32>

--- a/test/Passes/uKernels/bf16dp/pass-vector-contract-to-bf16dp.mlir
+++ b/test/Passes/uKernels/bf16dp/pass-vector-contract-to-bf16dp.mlir
@@ -182,3 +182,78 @@ module {
 // CHECK-LABEL: func.func @gemm_mixed_precision
 // CHECK: x86vector.avx512.dot
 // CHECK-COUNT-24: vector.store{{.*}}vector<16xf32>
+
+// -----
+
+#map_nm = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>
+#map_nm1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>
+#map_nm2 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
+module {
+  func.func @opt_register_4x6(%arg0: memref<1x4x16x2xbf16>, %arg1: memref<1x16x96x2xbf16>, %arg2: memref<4x96xbf16>) -> memref<4x96xbf16> {
+    %cst = arith.constant 0.000000e+00 : bf16
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c96 = arith.constant 96 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    scf.for %arg3 = %c0 to %c4 step %c4 {
+      scf.for %arg4 = %c0 to %c96 step %c96 {
+        %subview = memref.subview %arg2[%arg3, %arg4] [4, 96] [1, 1] : memref<4x96xbf16> to memref<4x96xbf16, strided<[96, 1], offset: ?>>
+        %0 = vector.transfer_read %subview[%c0, %c0], %cst {in_bounds = [true, true]} : memref<4x96xbf16, strided<[96, 1], offset: ?>>, vector<4x96xbf16>
+        %1 = scf.for %arg5 = %c0 to %c1 step %c1 iter_args(%arg6 = %0) -> (vector<4x96xbf16>) {
+          %2 = scf.for %arg7 = %c0 to %c16 step %c1 iter_args(%arg8 = %arg6) -> (vector<4x96xbf16>) {
+            %subview_0 = memref.subview %arg0[%arg5, %arg3, %arg7, 0] [1, 4, 1, 2] [1, 1, 1, 1] : memref<1x4x16x2xbf16> to memref<1x4x1x2xbf16, strided<[128, 32, 2, 1], offset: ?>>
+            %subview_1 = memref.subview %arg1[%arg5, %arg7, %arg4, 0] [1, 1, 96, 2] [1, 1, 1, 1] : memref<1x16x96x2xbf16> to memref<1x1x96x2xbf16, strided<[3072, 192, 2, 1], offset: ?>>
+            %3 = vector.transfer_read %subview_0[%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x4x1x2xbf16, strided<[128, 32, 2, 1], offset: ?>>, vector<1x4x1x2xbf16>
+            %4 = vector.transfer_read %subview_1[%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x1x96x2xbf16, strided<[3072, 192, 2, 1], offset: ?>>, vector<1x1x96x2xbf16>
+            %5 = vector.contract {indexing_maps = [#map_nm, #map_nm1, #map_nm2], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"], kind = #vector.kind<add>} %3, %4, %arg8 : vector<1x4x1x2xbf16>, vector<1x1x96x2xbf16> into vector<4x96xbf16>
+            scf.yield %5 : vector<4x96xbf16>
+          }
+          scf.yield %2 : vector<4x96xbf16>
+        }
+        vector.transfer_write %1, %subview[%c0, %c0] {in_bounds = [true, true]} : vector<4x96xbf16>, memref<4x96xbf16, strided<[96, 1], offset: ?>>
+      }
+    }
+    return %arg2 : memref<4x96xbf16>
+  }
+}
+
+// CHECK-LABEL:   func.func @opt_register_4x6
+// CHECK: scf.for
+// CHECK: scf.for
+// CHECK: scf.for
+// CHECK: scf.for
+// CHECK: vector.broadcast
+// CHECK: vector.broadcast
+// CHECK: vector.broadcast
+// CHECK: vector.broadcast
+// CHECK: vector.load
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: vector.load
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: vector.load
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: vector.load
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: vector.load
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: vector.load
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot
+// CHECK-NEXT: x86vector.avx512.dot


### PR DESCRIPTION
This `PR` update a small logic in the micro-kernels lowering based on `m` and `n` tile size. If:

-  `m >= n` - first load all B matrix elements, then broadcast A one-by-one + do `fma`.
- `n > m` - do the opposite. First broadcast all A matrix elements, then load B one-by-one + do `fma`

The logic is updated for `fp32` (both avx512 & avx2) and `bf16` (only avx512). 
`Bf16` avx2 will be done later after fixing the `llvm` pattern matching problem on `ADL` machine.