### PR TITLE
Support lowering of mixed precision vector.contract to AMX.

### DIFF
--- a/lib/TPP/Transforms/TransformUtils.cpp
+++ b/lib/TPP/Transforms/TransformUtils.cpp
@@ -268,9 +268,13 @@ isContraction(linalg::LinalgOp linalgOp) {
       .operation(NumDpsInits(EqualsTo(1)))
       .operation(NumDpsInputs(EqualsTo(2)))
       .operation(NumAffineMaps(EqualsTo(3)))
-      .region(MatchOne(0),
-            WithOpChain<arith::MulFOp,
-                        arith::AddFOp>(/*captures=*/nullptr));
+      .region(MatchOne(0), [&](Region *region, Operation *op) {
+        return WithOpChain<KindMul, KindAdd>(/*captures=*/nullptr)(region, op) ||
+               WithOpChain<arith::ExtFOp,
+                arith::ExtFOp, KindMul, KindAdd>(nullptr)(region, op) ||
+               WithOpChain<arith::ExtSIOp,
+                arith::ExtSIOp, KindMul, KindAdd>(nullptr)(region, op);
+      });
   // clang-format on
   if (!maybeContraction.match(linalgOp))
     return failure();

--- a/lib/TPP/Transforms/VectorContractToAMX.cpp
+++ b/lib/TPP/Transforms/VectorContractToAMX.cpp
@@ -36,6 +36,113 @@ using namespace mlir;
 using namespace mlir::tpp;
 
 namespace {
+// Helper function to down convert and copy the result back to the output
+// matrix.
+static void downConvertAndCopyResult(OpBuilder &rewriter, Location loc,
+                                     Value accBuffer, Value accSubview,
+                                     MemRefType bufferType, ShapedType accType,
+                                     Value c0, Value mBound, Value nBound,
+                                     Value one, Value sixteen) {
+  rewriter.create<scf::ForOp>(
+      loc, c0, mBound, one, ValueRange{},
+      [&](OpBuilder &nestedBuilder, Location loc, Value iv,
+          ValueRange iterArgs) {
+        nestedBuilder.create<scf::ForOp>(
+            loc, c0, nBound, sixteen, iterArgs,
+            [&](OpBuilder &innerBuilder, Location loc, Value innerIv,
+                ValueRange innerIterArgs) {
+              auto elementType = bufferType.getElementType();
+              FloatType floatType = cast<FloatType>(elementType);
+              Value f0 = rewriter.create<arith::ConstantFloatOp>(
+                  loc, APFloat::getZero(floatType.getFloatSemantics()),
+                  floatType);
+              // Read
+              auto readC = rewriter.create<vector::TransferReadOp>(
+                  loc, VectorType::get({16}, bufferType.getElementType()),
+                  accBuffer, ValueRange{iv, innerIv}, f0, ArrayRef{true});
+              // Convert
+              auto cvtF32ToBf16 = rewriter.create<arith::TruncFOp>(
+                  loc, VectorType::get({16}, accType.getElementType()), readC);
+              // Write
+              rewriter
+                  .create<vector::TransferWriteOp>(
+                      loc, cvtF32ToBf16, accSubview, ValueRange{iv, innerIv},
+                      ArrayRef{true})
+                  .getResult();
+
+              innerBuilder.create<scf::YieldOp>(loc);
+            });
+        // Yield results from inner loop to outer loop
+        nestedBuilder.create<scf::YieldOp>(loc);
+      });
+}
+
+// Helper function to up-convert and copy the accumulator.
+static void upConvertAndCopyAccumulator(OpBuilder &rewriter, Location loc,
+                                        Value accSubview, Value accBuffer,
+                                        Type inputElementType,
+                                        Type outputElementType, Value c0,
+                                        Value mBound, Value nBound, Value one,
+                                        Value sixteen) {
+  rewriter.create<scf::ForOp>(
+      loc, c0, mBound, one, ValueRange{},
+      [&](OpBuilder &nestedBuilder, Location loc, Value iv,
+          ValueRange iterArgs) {
+        nestedBuilder.create<scf::ForOp>(
+            loc, c0, nBound, sixteen, iterArgs,
+            [&](OpBuilder &innerBuilder, Location loc, Value innerIv,
+                ValueRange innerIterArgs) {
+              // Read
+              auto readC = rewriter.create<vector::TransferReadOp>(
+                  loc, VectorType::get({16}, inputElementType), accSubview,
+                  ValueRange{iv, innerIv}, ArrayRef{true});
+              auto bitcastLoad = rewriter.create<vector::BitCastOp>(
+                  loc, VectorType::get({16}, rewriter.getI16Type()), readC);
+              // Convert
+              auto cvtSIToUI32 = rewriter.create<arith::ExtSIOp>(
+                  loc, VectorType::get({16}, rewriter.getI32Type()),
+                  bitcastLoad);
+              int8_t bitsToShiftLeft = 16;
+              auto shiftLeft16bit = rewriter.create<arith::ShLIOp>(
+                  loc, cvtSIToUI32,
+                  rewriter.create<arith::ConstantOp>(
+                      loc, DenseElementsAttr::get(
+                               VectorType::get({16}, rewriter.getI32Type()),
+                               rewriter.getI32IntegerAttr(bitsToShiftLeft))));
+              auto bitcast = rewriter.create<arith::BitcastOp>(
+                  loc, VectorType::get({16}, rewriter.getF32Type()),
+                  shiftLeft16bit);
+              // Write
+              rewriter.create<vector::TransferWriteOp>(loc, bitcast, accBuffer,
+                                                       ValueRange{iv, innerIv},
+                                                       ArrayRef{true});
+              innerBuilder.create<scf::YieldOp>(loc);
+            });
+
+        // Yield results from inner loop to outer loop
+        nestedBuilder.create<scf::YieldOp>(loc);
+      });
+}
+
+// Helper function to initialize accumulators using amx.tile_load.
+static SmallVector<Value> initializeAccumulators(OpBuilder &rewriter,
+                                                 Location loc, Value buffer,
+                                                 Type accElementType, int64_t m,
+                                                 int64_t n) {
+  SmallVector<Value, 4> initAccs;
+  auto amxTile16x16xF32Ty = mlir::amx::TileType::get({16, 16}, accElementType);
+  for (auto mIndices = 0; mIndices < m; mIndices += 16) {
+    for (auto nIndices = 0; nIndices < n; nIndices += 16) {
+      auto acc = rewriter.create<amx::TileLoadOp>(
+          loc, amxTile16x16xF32Ty, buffer,
+          ValueRange{rewriter.create<arith::ConstantIndexOp>(loc, mIndices),
+                     rewriter.create<arith::ConstantIndexOp>(loc, nIndices)});
+      initAccs.push_back(acc);
+    }
+  }
+  return initAccs;
+}
+
 /// Returns true if the \p map is transposed.
 static bool isTransposed(AffineMap map) {
   auto numInputDims = map.getNumInputs();
@@ -272,10 +379,16 @@ static SmallVector<Value> createTileMuls(OpBuilder &builder, Location loc,
   SmallVector<Value> results;
   int numIterArgs = 0;
   for (unsigned i = 0; i < aLoadTiles.size(); i++) {
-    for (unsigned j = 0; j < bLoadTiles.size(); j++) {
-      auto amx = builder.create<amx::TileMulFOp>(
-          loc, resType, aLoadTiles[i], bLoadTiles[j], iterArgs[numIterArgs++]);
-      results.push_back(amx);
+    for (unsigned j = 0; j < aLoadTiles.size(); j++) {
+      auto amx =
+          resType.getElementType().isFloat()
+              ? builder.create<amx::TileMulFOp>(loc, resType, aLoadTiles[i],
+                                                bLoadTiles[j],
+                                                iterArgs[numIterArgs++])
+              : builder.create<amx::TileMulIOp>(loc, resType, aLoadTiles[i],
+                                                bLoadTiles[j],
+                                                iterArgs[numIterArgs++]);
+      results.push_back(amx->getResult(0));
     }
   }
   return results;
@@ -391,6 +504,10 @@ struct VectorContractToAMXPattern
     auto accType = cast<ShapedType>(accDefiningOp.getType());
     int64_t M = accType.getDimSize(0);
     int64_t N = accType.getDimSize(1);
+    // M and N must be equal and divisible by 16.
+    if (M != N || M % 16 != 0 || N % 16 != 0)
+      return rewriter.notifyMatchFailure(
+          op, "Output matrix dimensions must be equal and divisible by 16");
 
     auto accSubview = accDefiningOp.getBase();
     Location loc = op.getLoc();
@@ -399,9 +516,6 @@ struct VectorContractToAMXPattern
     rewriter.setInsertionPoint(insertAt->getBlock(),
                                std::next(insertAt->getIterator(), 1));
 
-    // Create a new buffer to hold the accumulator at higher precision.
-    auto bufferType = MemRefType::get({M, N}, rewriter.getF32Type());
-    auto accBuffer = rewriter.create<memref::AllocaOp>(loc, bufferType);
     Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
 
     // Up Convert and copy the original accumulator to the buffer.
@@ -409,63 +523,36 @@ struct VectorContractToAMXPattern
     auto sixteen = rewriter.create<arith::ConstantIndexOp>(loc, 16);
     auto mBound = rewriter.create<arith::ConstantIndexOp>(loc, M);
     auto nBound = rewriter.create<arith::ConstantIndexOp>(loc, N);
-    rewriter.create<scf::ForOp>(
-        loc, c0, mBound, one, ValueRange{},
-        [&](OpBuilder &nestedBuilder, Location loc, Value iv,
-            ValueRange iterArgs) {
-          nestedBuilder.create<scf::ForOp>(
-              loc, c0, nBound, sixteen, iterArgs,
-              [&](OpBuilder &innerBuilder, Location loc, Value innerIv,
-                  ValueRange innerIterArgs) {
-                // Create sequence of Read, Up-Convert and Write
-                auto readC = rewriter.create<vector::TransferReadOp>(
-                    loc, VectorType::get({16}, accType.getElementType()),
-                    accSubview, ValueRange{iv, innerIv}, std::nullopt /* padding */, 
-		    ArrayRef{true});
-                auto bitcastLoad = rewriter.create<vector::BitCastOp>(
-                    loc, VectorType::get({16}, rewriter.getI16Type()), readC);
-
-                auto cvtSIToUI32 = rewriter.create<arith::ExtSIOp>(
-                    loc, VectorType::get({16}, rewriter.getI32Type()),
-                    bitcastLoad);
-                int8_t bitsToShiftLeft = 16;
-                auto shiftLeft16bit = rewriter.create<arith::ShLIOp>(
-                    loc, cvtSIToUI32,
-                    rewriter.create<arith::ConstantOp>(
-                        loc, DenseElementsAttr::get(
-                                 VectorType::get({16}, rewriter.getI32Type()),
-                                 rewriter.getI32IntegerAttr(bitsToShiftLeft))));
-                auto bitcast = rewriter.create<arith::BitcastOp>(
-                    loc, VectorType::get({16}, rewriter.getF32Type()),
-                    shiftLeft16bit);
-
-                rewriter.create<vector::TransferWriteOp>(
-                    loc, bitcast, accBuffer, ValueRange{iv, innerIv},
-                    ArrayRef{true});
-                innerBuilder.create<scf::YieldOp>(loc);
-              });
-
-          // Yield results from inner loop to outer loop
-          nestedBuilder.create<scf::YieldOp>(loc);
-        });
 
     // Intialize each accumulator with a tileType of size 16x16
-    SmallVector<Value, 4> initAccs;
-    auto amxTile16x16xF32Ty =
-        mlir::amx::TileType::get({16, 16}, rewriter.getF32Type());
-    for (auto mIndices = 0; mIndices < M; mIndices += 16) {
-      for (auto nIndices = 0; nIndices < N; nIndices += 16) {
-        auto acc = rewriter.create<amx::TileLoadOp>(
-            loc, amxTile16x16xF32Ty, accBuffer,
-            ValueRange{rewriter.create<arith::ConstantIndexOp>(loc, mIndices),
-                       rewriter.create<arith::ConstantIndexOp>(loc, nIndices)});
-        initAccs.push_back(acc);
-      }
+    Type accElementType;
+    Type outputElementType = accType.getElementType();
+    outputElementType.isFloat() ? accElementType = rewriter.getF32Type()
+                                : accElementType = rewriter.getI32Type();
+
+    Value accBuffer;
+    MemRefType bufferType;
+    SmallVector<Value> initAccs;
+    if (outputElementType.isBF16()) {
+      // Create a new buffer to hold the accumulator at higher precision.
+      bufferType = MemRefType::get({M, N}, accElementType);
+      accBuffer = rewriter.create<memref::AllocaOp>(loc, bufferType);
+
+      // Up Convert and copy the original accumulator to the buffer.
+      upConvertAndCopyAccumulator(rewriter, loc, accSubview, accBuffer,
+                                  accType.getElementType(), accElementType, c0,
+                                  mBound, nBound, one, sixteen);
     }
+    initAccs = initializeAccumulators(
+        rewriter, loc, outputElementType.isBF16() ? accBuffer : accSubview,
+        accElementType, M, N);
 
     SmallVector<Value, 4> results;
+    auto amxTile16x16xF32Ty =
+        mlir::amx::TileType::get({16, 16}, accElementType);
+    auto inputTileElemType = lhsType.getElementType();
     auto amxInputTilesOf16x32xBf16Ty =
-        mlir::amx::TileType::get({16, 32}, rewriter.getBF16Type());
+        mlir::amx::TileType::get({16, 32}, inputTileElemType);
     // Lamda to create inner loop body.
     auto createLoopBody = [&](OpBuilder &innerBuilder, Location loc, Value iv,
                               Value innerIv, ValueRange innerIterArgs) {
@@ -566,7 +653,7 @@ struct VectorContractToAMXPattern
       for (auto mIndices = 0; mIndices < M; mIndices += 16) {
         for (auto nIndices = 0; nIndices < N; nIndices += 16) {
           rewriter.create<amx::TileStoreOp>(
-              loc, accBuffer,
+              loc, outputElementType.isBF16() ? accBuffer : accSubview,
               ValueRange{
                   rewriter.create<arith::ConstantIndexOp>(loc, mIndices),
                   rewriter.create<arith::ConstantIndexOp>(loc, nIndices)},
@@ -576,40 +663,10 @@ struct VectorContractToAMXPattern
     }
 
     // Down convert and copy the result back to the result matrix.
-    rewriter.create<scf::ForOp>(
-        loc, c0, mBound, one, ValueRange{},
-        [&](OpBuilder &nestedBuilder, Location loc, Value iv,
-            ValueRange iterArgs) {
-          nestedBuilder.create<scf::ForOp>(
-              loc, c0, nBound, sixteen, iterArgs,
-              [&](OpBuilder &innerBuilder, Location loc, Value innerIv,
-                  ValueRange innerIterArgs) {
-                auto elementType = bufferType.getElementType();
-                FloatType floatType = cast<FloatType>(elementType);
-                Value f0 = rewriter.create<arith::ConstantFloatOp>(
-                    loc, floatType,
-                    APFloat::getZero(floatType.getFloatSemantics()));
-
-                // Read
-                auto readC = rewriter.create<vector::TransferReadOp>(
-                    loc, VectorType::get({16}, bufferType.getElementType()),
-                    accBuffer, ValueRange{iv, innerIv}, f0, ArrayRef{true});
-                // Covert
-                auto cvtF32ToBf16 = rewriter.create<arith::TruncFOp>(
-                    loc, VectorType::get({16}, accType.getElementType()),
-                    readC);
-                // Write
-                rewriter
-                    .create<vector::TransferWriteOp>(
-                        loc, cvtF32ToBf16, accSubview, ValueRange{iv, innerIv},
-                        ArrayRef{true})
-                    .getResult();
-                innerBuilder.create<scf::YieldOp>(loc);
-              });
-
-          // Yield results from inner loop to outer loop
-          nestedBuilder.create<scf::YieldOp>(loc);
-        });
+    if (outputElementType.isBF16()) {
+      downConvertAndCopyResult(rewriter, loc, accBuffer, accSubview, bufferType,
+                               accType, c0, mBound, nBound, one, sixteen);
+    }
 
     // Erase original write.
     if (writeOp)
@@ -624,7 +681,6 @@ private:
 void VectorContractToAMX::runOnOperation() {
   auto funcOp = getOperation();
   MLIRContext *context = &getContext();
-
   RewritePatternSet patterns(context);
   patterns.add<VectorContractToAMXPattern>(context, ctx);
 

--- a/lib/TPP/Transforms/VectorContractToAMX.cpp
+++ b/lib/TPP/Transforms/VectorContractToAMX.cpp
@@ -129,7 +129,7 @@ static SmallVector<Value> initializeAccumulators(OpBuilder &rewriter,
                                                  Location loc, Value buffer,
                                                  Type accElementType, int64_t m,
                                                  int64_t n) {
-  SmallVector<Value, 4> initAccs;
+  SmallVector<Value> initAccs;
   auto amxTile16x16xF32Ty = mlir::amx::TileType::get({16, 16}, accElementType);
   for (auto mIndices = 0; mIndices < m; mIndices += 16) {
     for (auto nIndices = 0; nIndices < n; nIndices += 16) {

--- a/test/Passes/pass-vector-contract-to-amx.mlir
+++ b/test/Passes/pass-vector-contract-to-amx.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: target=x86{{.*}}
+// REQUIRES: x86-registered-target
 
 // RUN: tpp-opt %s  --vector-contract-to-amx --split-input-file | FileCheck %s
 
@@ -105,54 +105,99 @@ module {
 
 // -----
 
-#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>
-#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>
-#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
-
-memref.global "private" constant @__constant_16x32x64x2xbf16 : memref<16x32x64x2xbf16> = dense<1.000000e+00> {alignment = 64 : i64}
-func.func @entry(%arg0: memref<4x16x64x64xbf16>) -> memref<4x16x64x64xbf16> {
+func.func @entry(%arg0: memref<4x16x64x64xbf16>, %arg1: memref<16x16x32x64x2xbf16>, %arg2: memref<4x16x64x64xbf16>) {
   %cst = arith.constant 0.000000e+00 : bf16
-  %cst_0 = arith.constant dense<0.000000e+00> : vector<64x64xbf16>
+  %c32 = arith.constant 32 : index
   %c1 = arith.constant 1 : index
   %c16 = arith.constant 16 : index
-  %c32 = arith.constant 32 : index
   %c64 = arith.constant 64 : index
   %c0 = arith.constant 0 : index
-  %0 = memref.get_global @__constant_16x32x64x2xbf16 : memref<16x32x64x2xbf16>
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<4x16x64x64xbf16>
   %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [4, 16, 64, 32, 2] : memref<4x16x64x64xbf16> into memref<4x16x64x32x2xbf16>
-  scf.forall (%arg1, %arg2) in (4, 16) {
-    %subview = memref.subview %alloc[%arg1, %arg2, 0, 0] [1, 1, 64, 64] [1, 1, 1, 1] : memref<4x16x64x64xbf16> to memref<64x64xbf16, strided<[64, 1], offset: ?>>
-    vector.transfer_write %cst_0, %subview[%c0, %c0] {in_bounds = [true, true]} : vector<64x64xbf16>, memref<64x64xbf16, strided<[64, 1], offset: ?>>
-    %subview_1 = memref.subview %expand_shape[%arg1, 0, 0, 0, 0] [1, 16, 64, 32, 2] [1, 1, 1, 1, 1] : memref<4x16x64x32x2xbf16> to memref<16x64x32x2xbf16, strided<[4096, 64, 2, 1], offset: ?>>
-    scf.for %arg3 = %c0 to %c64 step %c64 {
-      scf.for %arg4 = %c0 to %c64 step %c32 {
-        %subview_2 = memref.subview %subview[%arg3, %arg4] [64, 32] [1, 1] : memref<64x64xbf16, strided<[64, 1], offset: ?>> to memref<64x32xbf16, strided<[64, 1], offset: ?>>
-        %1 = vector.transfer_read %subview_2[%c0, %c0], %cst {in_bounds = [true, true]} : memref<64x32xbf16, strided<[64, 1], offset: ?>>, vector<64x32xbf16>
-        %2 = scf.for %arg5 = %c0 to %c16 step %c1 iter_args(%arg6 = %1) -> (vector<64x32xbf16>) {
-          %3 = scf.for %arg7 = %c0 to %c32 step %c16 iter_args(%arg8 = %arg6) -> (vector<64x32xbf16>) {
-            %subview_3 = memref.subview %subview_1[%arg5, %arg3, %arg7, 0] [1, 64, 16, 2] [1, 1, 1, 1] : memref<16x64x32x2xbf16, strided<[4096, 64, 2, 1], offset: ?>> to memref<1x64x16x2xbf16, strided<[4096, 64, 2, 1], offset: ?>>
-            %subview_4 = memref.subview %0[%arg5, %arg7, %arg4, 0] [1, 16, 32, 2] [1, 1, 1, 1] : memref<16x32x64x2xbf16> to memref<1x16x32x2xbf16, strided<[4096, 128, 2, 1], offset: ?>>
-            %4 = vector.transfer_read %subview_3[%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x64x16x2xbf16, strided<[4096, 64, 2, 1], offset: ?>>, vector<1x64x16x2xbf16>
-            %5 = vector.transfer_read %subview_4[%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x16x32x2xbf16, strided<[4096, 128, 2, 1], offset: ?>>, vector<1x16x32x2xbf16>
-            %6 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"], kind = #vector.kind<add>} %4, %5, %arg8 : vector<1x64x16x2xbf16>, vector<1x16x32x2xbf16> into vector<64x32xbf16>
-            scf.yield %6 : vector<64x32xbf16>
+  scf.forall (%arg3, %arg4) in (4, 16) {
+    %subview = memref.subview %expand_shape[%arg3, 0, 0, 0, 0] [1, 16, 64, 32, 2] [1, 1, 1, 1, 1] : memref<4x16x64x32x2xbf16> to memref<16x64x32x2xbf16, strided<[4096, 64, 2, 1], offset: ?>>
+    %subview_0 = memref.subview %arg1[%arg4, 0, 0, 0, 0] [1, 16, 32, 64, 2] [1, 1, 1, 1, 1] : memref<16x16x32x64x2xbf16> to memref<16x32x64x2xbf16, strided<[4096, 128, 2, 1], offset: ?>>
+    %subview_1 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 64, 64] [1, 1, 1, 1] : memref<4x16x64x64xbf16> to memref<64x64xbf16, strided<[64, 1], offset: ?>>
+    scf.for %arg5 = %c0 to %c64 step %c64 {
+      scf.for %arg6 = %c0 to %c64 step %c64 {
+        %subview_2 = memref.subview %subview_1[%arg5, %arg6] [64, 64] [1, 1] : memref<64x64xbf16, strided<[64, 1], offset: ?>> to memref<64x64xbf16, strided<[64, 1], offset: ?>>
+        %0 = vector.transfer_read %subview_2[%c0, %c0], %cst {in_bounds = [true, true]} : memref<64x64xbf16, strided<[64, 1], offset: ?>>, vector<64x64xbf16>
+        %1 = scf.for %arg7 = %c0 to %c16 step %c1 iter_args(%arg8 = %0) -> (vector<64x64xbf16>) {
+          %2 = scf.for %arg9 = %c0 to %c32 step %c16 iter_args(%arg10 = %arg8) -> (vector<64x64xbf16>) {
+            %subview_3 = memref.subview %subview[%arg7, %arg5, %arg9, 0] [1, 64, 16, 2] [1, 1, 1, 1] : memref<16x64x32x2xbf16, strided<[4096, 64, 2, 1], offset: ?>> to memref<1x64x16x2xbf16, strided<[4096, 64, 2, 1], offset: ?>>
+            %subview_4 = memref.subview %subview_0[%arg7, %arg9, %arg6, 0] [1, 16, 64, 2] [1, 1, 1, 1] : memref<16x32x64x2xbf16, strided<[4096, 128, 2, 1], offset: ?>> to memref<1x16x64x2xbf16, strided<[4096, 128, 2, 1], offset: ?>>
+            %3 = vector.transfer_read %subview_3[%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x64x16x2xbf16, strided<[4096, 64, 2, 1], offset: ?>>, vector<1x64x16x2xbf16>
+            %4 = vector.transfer_read %subview_4[%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x16x64x2xbf16, strided<[4096, 128, 2, 1], offset: ?>>, vector<1x16x64x2xbf16>
+            %5 = vector.contract {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"], kind = #vector.kind<add>} %3, %4, %arg10 : vector<1x64x16x2xbf16>, vector<1x16x64x2xbf16> into vector<64x64xbf16>
+            scf.yield %5 : vector<64x64xbf16>
           }
-          scf.yield %3 : vector<64x32xbf16>
+          scf.yield %2 : vector<64x64xbf16>
         }
-        vector.transfer_write %2, %subview_2[%c0, %c0] {in_bounds = [true, true]} : vector<64x32xbf16>, memref<64x32xbf16, strided<[64, 1], offset: ?>>
+        vector.transfer_write %1, %subview_2[%c0, %c0] {in_bounds = [true, true]} : vector<64x64xbf16>, memref<64x64xbf16, strided<[64, 1], offset: ?>>
       }
     }
   }
-  return %alloc : memref<4x16x64x64xbf16>
+  return
 }
 
 // CHECK-LABEL:   func.func @entry
-// CHECK:             memref.alloca() : memref<64x32xf32>
-// CHECK:             amx.tile_load
-// CHECK:             amx.tile_load
+// CHECK:             memref.alloca() : memref<64x64xf32>
+// CHECK-COUNT-16:    amx.tile_load
+// CHECK-COUNT-2:     scf.for
+// CHECK-COUNT-8:     amx.tile_load
 // CHECK-COUNT-8:     amx.tile_mulf
-// CHECK:             amx.tile_store
+// CHECK-COUNT-16:    amx.tile_store
 // CHECK:             vector.transfer_read
 // CHECK:             arith.truncf
 // CHECK:             vector.transfer_write
+
+// -----
+
+// This tests shows the lowering of a mixed precision vector.contract
+// (bf16 x bf16 -> fp32) to AMX dialect.
+func.func @entry(%arg0: memref<8x32x32x32xbf16>, %arg1: memref<2x32x16x32x2xbf16>, %arg2: memref<8x2x32x32xf32>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %cst_0 = arith.constant 0.000000e+00 : bf16
+  %c16 = arith.constant 16 : index
+  %c1 = arith.constant 1 : index
+  %c32 = arith.constant 32 : index
+  %c0 = arith.constant 0 : index
+  %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [8, 32, 32, 16, 2] : memref<8x32x32x32xbf16> into memref<8x32x32x16x2xbf16>
+  scf.forall (%arg3, %arg4) in (8, 2) {
+    %subview = memref.subview %expand_shape[%arg3, 0, 0, 0, 0] [1, 32, 32, 16, 2] [1, 1, 1, 1, 1] : memref<8x32x32x16x2xbf16> to memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
+    %subview_1 = memref.subview %arg1[%arg4, 0, 0, 0, 0] [1, 32, 16, 32, 2] [1, 1, 1, 1, 1] : memref<2x32x16x32x2xbf16> to memref<32x16x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>
+    %subview_2 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x2x32x32xf32> to memref<32x32xf32, strided<[32, 1], offset: ?>>
+    scf.for %arg5 = %c0 to %c32 step %c32 {
+      scf.for %arg6 = %c0 to %c32 step %c32 {
+        %subview_3 = memref.subview %subview_2[%arg5, %arg6] [32, 32] [1, 1] : memref<32x32xf32, strided<[32, 1], offset: ?>> to memref<32x32xf32, strided<[32, 1], offset: ?>>
+        %0 = vector.transfer_read %subview_3[%c0, %c0], %cst {in_bounds = [true, true]} : memref<32x32xf32, strided<[32, 1], offset: ?>>, vector<32x32xf32>
+        %1 = scf.for %arg7 = %c0 to %c32 step %c1 iter_args(%arg8 = %0) -> (vector<32x32xf32>) {
+          %2 = scf.for %arg9 = %c0 to %c16 step %c16 iter_args(%arg10 = %arg8) -> (vector<32x32xf32>) {
+            %subview_4 = memref.subview %subview[%arg7, %arg5, %arg9, 0] [1, 32, 16, 2] [1, 1, 1, 1] : memref<32x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>> to memref<1x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
+            %subview_5 = memref.subview %subview_1[%arg7, %arg9, %arg6, 0] [1, 16, 32, 2] [1, 1, 1, 1] : memref<32x16x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>> to memref<1x16x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>
+            %3 = vector.transfer_read %subview_4[%c0, %c0, %c0, %c0], %cst_0 {in_bounds = [true, true, true, true]} : memref<1x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, vector<1x32x16x2xbf16>
+            %4 = vector.transfer_read %subview_5[%c0, %c0, %c0, %c0], %cst_0 {in_bounds = [true, true, true, true]} : memref<1x16x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>, vector<1x16x32x2xbf16>
+            %5 = vector.contract {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"], kind = #vector.kind<add>} %3, %4, %arg10 : vector<1x32x16x2xbf16>, vector<1x16x32x2xbf16> into vector<32x32xf32>
+            scf.yield %5 : vector<32x32xf32>
+          }
+          scf.yield %2 : vector<32x32xf32>
+        }
+        vector.transfer_write %1, %subview_3[%c0, %c0] {in_bounds = [true, true]} : vector<32x32xf32>, memref<32x32xf32, strided<[32, 1], offset: ?>>
+      }
+    }
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @entry
+// CHECK-COUNT-4:     amx.tile_load
+// CHECK-COUNT-2:     scf.for
+// CHECK-COUNT-1:     collapse_shape
+// CHECK-COUNT-1:     amx.tile_load
+// CHECK-COUNT-1:     collapse_shape
+// CHECK-COUNT-1:     amx.tile_load
+// CHECK-COUNT-1:     collapse_shape
+// CHECK-COUNT-1:     amx.tile_load
+// CHECK-COUNT-1:     collapse_shape
+// CHECK-COUNT-1:     amx.tile_load
+// CHECK-COUNT-4:     amx.tile_mulf
+// CHECK-COUNT-4:    amx.tile_store

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -49,4 +49,11 @@ llvm_config.with_environment("PATH", config.llvm_tools_dir, append_path=True)
 tool_dirs = [config.tpp_tools_dir, config.llvm_tools_dir]
 tools = ["mlir-gen", "tpp-opt", "tpp-run", "fpcmp", "tpp-sched"]
 
+# Define '*-registered-target' feature for each target for 'REQUIRES' directive
+# to work as expected.
+config.targets = frozenset(config.targets_to_build.split())
+
+for arch in config.targets_to_build.split():
+    config.available_features.add(arch.lower() + "-registered-target")
+
 llvm_config.add_tool_substitutions(tools, tool_dirs)


### PR DESCRIPTION
This patch support mixed precision lowering of vector.contract with bf16/i8 input and fp32/i32 output type respectively
while also refactoring the code for readability/modularity. Moreover, it also prepares for other possible mixed precision
operation.

It was observed that the 'REQUIRES' directive was not working due to a lit config gap. This also fixes the observed issue.