### PR TITLE
[mlir-gen] Add mixed precision type support(1/N).

### DIFF
--- a/test/Integration/mlir-gen-matmul.mlir
+++ b/test/Integration/mlir-gen-matmul.mlir
@@ -2,6 +2,14 @@
 // RUN: mlir-gen --kernel=args --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=BF16
 // RUN: mlir-gen --kernel=args --seed=0 --float-type=f16 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP16
 
+// RUN: mlir-gen --kernel=args --seed=0 --float-type=mx-bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=MXBF16-GENERIC
+// RUN: mlir-gen --kernel=args --seed=0 --float-type=mx-i8 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=MXI8-GENERIC
+// RUN: mlir-gen --kernel=args --seed=0 --float-type=mx-f16 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=MXF16-GENERIC
+
+// RUN: mlir-gen --kernel=args --seed=0 --float-type=mx-bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --output=contract 2>&1 | FileCheck %s --check-prefix=MXBF16-CONTRACT
+// RUN: mlir-gen --kernel=args --seed=0 --float-type=mx-i8 --batch=128 --layers=2304,768 --tiles=64,48,64 --output=contract 2>&1 | FileCheck %s --check-prefix=MXI8-CONTRACT
+// RUN: mlir-gen --kernel=args --seed=0 --float-type=mx-f16 --batch=128 --layers=2304,768 --tiles=64,48,64 --output=contract 2>&1 | FileCheck %s --check-prefix=MXF16-CONTRACT
+
 // FP32: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // FP32: // RUN{{.*}}-e entry -entry-point-result=void
 // FP32: // BENCH_TOTAL_FLOPS: 452984832
@@ -40,3 +48,90 @@
 // FP16:         arith.mulf
 // FP16:         arith.addf
 // FP16-NOT: dealloc
+
+// MXBF16-GENERIC: #[[$ATTR_0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+// MXBF16-GENERIC: #[[$ATTR_1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+// MXBF16-GENERIC: #[[$ATTR_2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+// MXBF16-GENERIC-LABEL:   func.func @entry(
+// MXBF16-GENERIC-SAME:                     %[[ARG0:.*]]: tensor<2x36x64x64xbf16>,
+// MXBF16-GENERIC-SAME:                     %[[ARG1:.*]]: tensor<16x36x64x48xbf16>,
+// MXBF16-GENERIC-SAME:                     %[[ARG2:.*]]: tensor<2x16x64x48xf32>) -> tensor<2x16x64x48xf32> {
+// MXBF16-GENERIC:           %[[VAL_0:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_1]], #[[$ATTR_2]]], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%[[ARG0]], %[[ARG1]] : tensor<2x36x64x64xbf16>, tensor<16x36x64x48xbf16>) outs(%[[ARG2]] : tensor<2x16x64x48xf32>) {
+// MXBF16-GENERIC:           ^bb0(%[[VAL_1:.*]]: bf16, %[[VAL_2:.*]]: bf16, %[[VAL_3:.*]]: f32):
+// MXBF16-GENERIC:             %[[VAL_4:.*]] = arith.extf %[[VAL_1]] : bf16 to f32
+// MXBF16-GENERIC:             %[[VAL_5:.*]] = arith.extf %[[VAL_2]] : bf16 to f32
+// MXBF16-GENERIC:             %[[VAL_6:.*]] = arith.mulf %[[VAL_4]], %[[VAL_5]] : f32
+// MXBF16-GENERIC:             %[[VAL_7:.*]] = arith.addf %[[VAL_3]], %[[VAL_6]] : f32
+// MXBF16-GENERIC:             linalg.yield %[[VAL_7]] : f32
+// MXBF16-GENERIC:           } -> tensor<2x16x64x48xf32>
+// MXBF16-GENERIC:           return %[[VAL_0]] : tensor<2x16x64x48xf32>
+// MXBF16-GENERIC:         }
+
+// MXI8-GENERIC: #[[$ATTR_0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+// MXI8-GENERIC: #[[$ATTR_1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+// MXI8-GENERIC: #[[$ATTR_2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+// MXI8-GENERIC-LABEL:   func.func @entry(
+// MXI8-GENERIC-SAME:                     %[[ARG0:.*]]: tensor<2x36x64x64xi8>,
+// MXI8-GENERIC-SAME:                     %[[ARG1:.*]]: tensor<16x36x64x48xi8>,
+// MXI8-GENERIC-SAME:                     %[[ARG2:.*]]: tensor<2x16x64x48xi32>) -> tensor<2x16x64x48xi32> {
+// MXI8-GENERIC:           %[[VAL_0:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_1]], #[[$ATTR_2]]], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%[[ARG0]], %[[ARG1]] : tensor<2x36x64x64xi8>, tensor<16x36x64x48xi8>) outs(%[[ARG2]] : tensor<2x16x64x48xi32>) {
+// MXI8-GENERIC:           ^bb0(%[[VAL_1:.*]]: i8, %[[VAL_2:.*]]: i8, %[[VAL_3:.*]]: i32):
+// MXI8-GENERIC:             %[[VAL_4:.*]] = arith.extsi %[[VAL_1]] : i8 to i32
+// MXI8-GENERIC:             %[[VAL_5:.*]] = arith.extsi %[[VAL_2]] : i8 to i32
+// MXI8-GENERIC:             %[[VAL_6:.*]] = arith.muli %[[VAL_4]], %[[VAL_5]] : i32
+// MXI8-GENERIC:             %[[VAL_7:.*]] = arith.addi %[[VAL_3]], %[[VAL_6]] : i32
+// MXI8-GENERIC:             linalg.yield %[[VAL_7]] : i32
+// MXI8-GENERIC:           } -> tensor<2x16x64x48xi32>
+// MXI8-GENERIC:           return %[[VAL_0]] : tensor<2x16x64x48xi32>
+// MXI8-GENERIC:         }
+
+// MXBF16-CONTRACT: #[[$ATTR_0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+// MXBF16-CONTRACT: #[[$ATTR_1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+// MXBF16-CONTRACT: #[[$ATTR_2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+// MXBF16-CONTRACT-LABEL:   func.func @entry(
+// MXBF16-CONTRACT-SAME:                     %[[ARG0:.*]]: tensor<2x36x64x64xbf16>,
+// MXBF16-CONTRACT-SAME:                     %[[ARG1:.*]]: tensor<16x36x64x48xbf16>,
+// MXBF16-CONTRACT-SAME:                     %[[ARG2:.*]]: tensor<2x16x64x48xf32>) -> tensor<2x16x64x48xf32> {
+// MXBF16-CONTRACT:           %[[VAL_0:.*]] = linalg.contract indexing_maps = [#[[$ATTR_0]], #[[$ATTR_1]], #[[$ATTR_2]]] ins(%[[ARG0]], %[[ARG1]] : tensor<2x36x64x64xbf16>, tensor<16x36x64x48xbf16>) outs(%[[ARG2]] : tensor<2x16x64x48xf32>) -> tensor<2x16x64x48xf32>
+// MXBF16-CONTRACT:           return %[[VAL_0]] : tensor<2x16x64x48xf32>
+// MXBF16-CONTRACT:         }
+
+// MXI8-CONTRACT: #[[$ATTR_0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+// MXI8-CONTRACT: #[[$ATTR_1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+// MXI8-CONTRACT: #[[$ATTR_2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+// MXI8-CONTRACT-LABEL:   func.func @entry(
+// MXI8-CONTRACT-SAME:                     %[[ARG0:.*]]: tensor<2x36x64x64xi8>,
+// MXI8-CONTRACT-SAME:                     %[[ARG1:.*]]: tensor<16x36x64x48xi8>,
+// MXI8-CONTRACT-SAME:                     %[[ARG2:.*]]: tensor<2x16x64x48xi32>) -> tensor<2x16x64x48xi32> {
+// MXI8-CONTRACT:           %[[VAL_0:.*]] = linalg.contract indexing_maps = [#[[$ATTR_0]], #[[$ATTR_1]], #[[$ATTR_2]]] ins(%[[ARG0]], %[[ARG1]] : tensor<2x36x64x64xi8>, tensor<16x36x64x48xi8>) outs(%[[ARG2]] : tensor<2x16x64x48xi32>) -> tensor<2x16x64x48xi32>
+// MXI8-CONTRACT:           return %[[VAL_0]] : tensor<2x16x64x48xi32>
+// MXI8-CONTRACT:         }
+
+// MXF16-GENERIC: #[[$ATTR_0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+// MXF16-GENERIC: #[[$ATTR_1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+// MXF16-GENERIC: #[[$ATTR_2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+// MXF16-GENERIC-LABEL:   func.func @entry(
+// MXF16-GENERIC-SAME:                     %[[ARG0:.*]]: tensor<2x36x64x64xf16>,
+// MXF16-GENERIC-SAME:                     %[[ARG1:.*]]: tensor<16x36x64x48xf16>,
+// MXF16-GENERIC-SAME:                     %[[ARG2:.*]]: tensor<2x16x64x48xf32>) -> tensor<2x16x64x48xf32> {
+// MXF16-GENERIC:           %[[VAL_0:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_1]], #[[$ATTR_2]]], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%[[ARG0]], %[[ARG1]] : tensor<2x36x64x64xf16>, tensor<16x36x64x48xf16>) outs(%[[ARG2]] : tensor<2x16x64x48xf32>) {
+// MXF16-GENERIC:           ^bb0(%[[VAL_1:.*]]: f16, %[[VAL_2:.*]]: f16, %[[VAL_3:.*]]: f32):
+// MXF16-GENERIC:             %[[VAL_4:.*]] = arith.extf %[[VAL_1]] : f16 to f32
+// MXF16-GENERIC:             %[[VAL_5:.*]] = arith.extf %[[VAL_2]] : f16 to f32
+// MXF16-GENERIC:             %[[VAL_6:.*]] = arith.mulf %[[VAL_4]], %[[VAL_5]] : f32
+// MXF16-GENERIC:             %[[VAL_7:.*]] = arith.addf %[[VAL_3]], %[[VAL_6]] : f32
+// MXF16-GENERIC:             linalg.yield %[[VAL_7]] : f32
+// MXF16-GENERIC:           } -> tensor<2x16x64x48xf32>
+// MXF16-GENERIC:           return %[[VAL_0]] : tensor<2x16x64x48xf32>
+// MXF16-GENERIC:         }
+
+// MXF16-CONTRACT: #[[$ATTR_0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+// MXF16-CONTRACT: #[[$ATTR_1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+// MXF16-CONTRACT: #[[$ATTR_2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+// MXF16-CONTRACT-LABEL:   func.func @entry(
+// MXF16-CONTRACT-SAME:                     %[[ARG0:.*]]: tensor<2x36x64x64xf16>,
+// MXF16-CONTRACT-SAME:                     %[[ARG1:.*]]: tensor<16x36x64x48xf16>,
+// MXF16-CONTRACT-SAME:                     %[[ARG2:.*]]: tensor<2x16x64x48xf32>) -> tensor<2x16x64x48xf32> {
+// MXF16-CONTRACT:           %[[VAL_0:.*]] = linalg.contract indexing_maps = [#[[$ATTR_0]], #[[$ATTR_1]], #[[$ATTR_2]]] ins(%[[ARG0]], %[[ARG1]] : tensor<2x36x64x64xf16>, tensor<16x36x64x48xf16>) outs(%[[ARG2]] : tensor<2x16x64x48xf32>) -> tensor<2x16x64x48xf32>
+// MXF16-CONTRACT:           return %[[VAL_0]] : tensor<2x16x64x48xf32>
+// MXF16-CONTRACT:         }

--- a/tools/mlir-gen/MLIRGen.cpp
+++ b/tools/mlir-gen/MLIRGen.cpp
@@ -115,19 +115,19 @@ MLIRGenerator::MLIRGenerator(StringRef outputOpKindStr, StringRef kernelStr,
 
   // Pick data type
   auto elementType =
-      llvm::StringSwitch<std::optional<SmallVector<mlir::Type, 3>>>(targetType)
-          .CaseLower("f32", SmallVector<Type, 3>{builder.getF32Type(),
+      llvm::StringSwitch<std::optional<SmallVector<mlir::Type>>>(targetType)
+          .CaseLower("f32", SmallVector<Type>{builder.getF32Type(),
+                                              builder.getF32Type()})
+          .CaseLower("f16", SmallVector<Type>{builder.getF16Type(),
+                                              builder.getF16Type()})
+          .CaseLower("bf16", SmallVector<Type>{builder.getBF16Type(),
+                                               builder.getBF16Type()})
+          .CaseLower("mx-bf16", SmallVector<Type>{builder.getBF16Type(),
+                                                  builder.getF32Type()})
+          .CaseLower("mx-f16", SmallVector<Type>{builder.getF16Type(),
                                                  builder.getF32Type()})
-          .CaseLower("f16", SmallVector<Type, 3>{builder.getF16Type(),
-                                                 builder.getF16Type()})
-          .CaseLower("bf16", SmallVector<Type, 3>{builder.getBF16Type(),
-                                                  builder.getBF16Type()})
-          .CaseLower("mx-bf16", SmallVector<Type, 2>{builder.getBF16Type(),
-                                                     builder.getF32Type()})
-          .CaseLower("mx-f16", SmallVector<Type, 3>{builder.getF16Type(),
-                                                    builder.getF32Type()})
-          .CaseLower("mx-i8", SmallVector<Type, 3>{builder.getIntegerType(8),
-                                                   builder.getI32Type()})
+          .CaseLower("mx-i8", SmallVector<Type>{builder.getIntegerType(8),
+                                                builder.getI32Type()})
           .Default(std::nullopt);
   assert(elementType && "Unsupported data type");
   dataTypes.push_back((*elementType)[0]);

--- a/tools/mlir-gen/MLIRGen.h
+++ b/tools/mlir-gen/MLIRGen.h
@@ -52,7 +52,7 @@ class MLIRGenerator {
   SmallVector<int64_t> tiles;
 
   /// Data type (element type of all tensors)
-  SmallVector<Type, 3> dataTypes;
+  SmallVector<Type> dataTypes;
 
   /// Random seed
   int seed;

--- a/tools/mlir-gen/MLIRGen.h
+++ b/tools/mlir-gen/MLIRGen.h
@@ -52,7 +52,7 @@ class MLIRGenerator {
   SmallVector<int64_t> tiles;
 
   /// Data type (element type of all tensors)
-  Type dataType;
+  SmallVector<Type, 3> dataTypes;
 
   /// Random seed
   int seed;

--- a/tools/mlir-gen/mlir-gen.cpp
+++ b/tools/mlir-gen/mlir-gen.cpp
@@ -68,7 +68,8 @@ llvm::cl::opt<std::string>
 // Float type
 llvm::cl::opt<std::string>
     floatType("float-type", llvm::cl::desc("Float type and its bitsize"),
-              llvm::cl::value_desc("f32|f16|bf16"), llvm::cl::init("f32"));
+              llvm::cl::value_desc("f32|f16|bf16|mx-bf16|mx-f16|mx-i8"),
+              llvm::cl::init("f32"));
 
 // Random seed
 llvm::cl::opt<int> seed("seed", llvm::cl::desc("Random seed"),


### PR DESCRIPTION
Adds creation of gemm kernels with mixed types such as bf16 -> fp32, f16 -> f32, i8 -> i32.