### PR TITLE
[Init] Add identity initializer

### DIFF
--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -578,7 +578,7 @@ def TppRunnerWrapper : Pass<"tpp-runner-wrapper", "ModuleOp">{
             /*default=*/"",
            "Initializer type (const, simple, cont, rand, normal).">,
     Option<"identity", "identity", "int64_t",
-            /*default=*/"0",
+            /*default=*/"-1",
            "Identity square argument (-1=none, 0=a, 1=b).">,
   ];
 }

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -577,6 +577,9 @@ def TppRunnerWrapper : Pass<"tpp-runner-wrapper", "ModuleOp">{
     Option<"initType", "init-type", "std::string",
             /*default=*/"",
            "Initializer type (const, simple, cont, rand, normal).">,
+    Option<"identity", "identity", "std::string",
+            /*default=*/"",
+           "Identity square argument (a, b).">,
   ];
 }
 

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -577,9 +577,9 @@ def TppRunnerWrapper : Pass<"tpp-runner-wrapper", "ModuleOp">{
     Option<"initType", "init-type", "std::string",
             /*default=*/"",
            "Initializer type (const, simple, cont, rand, normal).">,
-    Option<"identity", "identity", "std::string",
-            /*default=*/"",
-           "Identity square argument (a, b).">,
+    Option<"identity", "identity", "int64_t",
+            /*default=*/"0",
+           "Identity square argument (-1=none, 0=a, 1=b).">,
   ];
 }
 

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -579,7 +579,7 @@ def TppRunnerWrapper : Pass<"tpp-runner-wrapper", "ModuleOp">{
            "Initializer type (const, simple, cont, rand, normal).">,
     Option<"identity", "identity", "int64_t",
             /*default=*/"-1",
-           "Identity square argument (-1=none, 0=a, 1=b).">,
+           "Identity square argument (-1=none, 0=a, 1=b, ...).">,
   ];
 }
 

--- a/include/TPP/Runner/MLIRBench.h
+++ b/include/TPP/Runner/MLIRBench.h
@@ -47,7 +47,7 @@ struct MLIRBenchConfig {
 
   int seed = 0;
   TensorInitType initType = TensorInitType::Auto;
-  int identity = 0;
+  int identity = -1;
   std::string backend = "cpu";
   bool offloadToDevice = true;
 };

--- a/include/TPP/Runner/MLIRBench.h
+++ b/include/TPP/Runner/MLIRBench.h
@@ -40,13 +40,14 @@ class FuncOp;
 // pipeline.
 struct MLIRBenchConfig {
   MLIRBenchConfig() = default;
-  MLIRBenchConfig(int seed, TensorInitType initType, std::string backend,
+  MLIRBenchConfig(int seed, TensorInitType initType, int identity, std::string backend,
                   bool offloadToDevice)
-      : seed(seed), initType(initType), backend(backend),
+      : seed(seed), initType(initType), identity(identity), backend(backend),
         offloadToDevice(offloadToDevice) {}
 
   int seed = 0;
   TensorInitType initType = TensorInitType::Auto;
+  int identity = 0;
   std::string backend = "cpu";
   bool offloadToDevice = true;
 };
@@ -84,6 +85,9 @@ class MLIRBench {
 
   /// Seed for the random tensor filling
   int seed;
+
+  /// Which argument is the identity, if any
+  int identity;
 
   /// Tensor init type
   TensorInitType initType;

--- a/include/TPP/Transforms/Utils/TensorInit.h
+++ b/include/TPP/Transforms/Utils/TensorInit.h
@@ -120,4 +120,8 @@ TensorInitPtr getTensorInit(TensorInitType type, mlir::Type elmType,
 TensorInitPtr getTensorInit(llvm::StringRef type, mlir::Type elmType,
                             int seed = 0);
 
+// Return the numeric ID of the identity argument
+// -1 for none, 0 for A, 1 for B
+llvm::FailureOr<int> getIdentityOption(llvm::StringRef identity);
+
 #endif // TPP_TRANSFORMS_UTILS_TENSORINIT_H

--- a/include/TPP/Transforms/Utils/TensorInit.h
+++ b/include/TPP/Transforms/Utils/TensorInit.h
@@ -120,8 +120,4 @@ TensorInitPtr getTensorInit(TensorInitType type, mlir::Type elmType,
 TensorInitPtr getTensorInit(llvm::StringRef type, mlir::Type elmType,
                             int seed = 0);
 
-// Return the numeric ID of the identity argument
-// -1 for none, 0 for A, 1 for B
-llvm::FailureOr<int> getIdentityOption(llvm::StringRef identity);
-
 #endif // TPP_TRANSFORMS_UTILS_TENSORINIT_H

--- a/include/TPP/Transforms/Utils/TensorInitFloat.h
+++ b/include/TPP/Transforms/Utils/TensorInitFloat.h
@@ -90,24 +90,8 @@ struct ConstantTensorInitFloat : TensorInitFloat {
   ConstantTensorInitFloat(DataType type) : TensorInitFloat(type) {}
 
   // Return a dense<1.0> repeated throughout the shape.
-  mlir::DenseElementsAttr get(mlir::ShapedType shape) override;
+  mlir::FailureOr<mlir::DenseElementsAttr> get(mlir::ShapedType shape) override;
 
-  void fillData() override;
-};
-
-// Simple init (basic example, not useful).
-struct SimpleTensorInitFloat : TensorInitFloat {
-  SimpleTensorInitFloat(DataType type) : TensorInitFloat(type) {}
-
-  // Return a dense<0.3, 0.6, 0.9> repeated throughout the shape.
-  void fillData() override;
-};
-
-// Continuous init (normalized affine range).
-struct ContinuousTensorInitFloat : TensorInitFloat {
-  ContinuousTensorInitFloat(DataType type) : TensorInitFloat(type) {}
-
-  // Return a dense<0.0 ... 1.0> throughout the shape.
   void fillData() override;
 };
 
@@ -149,6 +133,26 @@ private:
   std::default_random_engine generator;
   // Random distribution.
   std::normal_distribution<float> distribution;
+};
+
+// Identity init.
+struct IdentityTensorInitFloat : TensorInitFloat {
+  IdentityTensorInitFloat(DataType type)
+      : TensorInitFloat(type) {}
+
+  // Makes sure the shape is "square"
+  bool checkShape(mlir::ShapedType shape) override {
+    if (!TensorInit::checkShape(shape))
+      return false;
+    // Now the fields are set, compare all dims to be equal, 2D only for now
+    return dims.size() == 2 && dims[0] == dims[1];
+  }
+
+  // Should not be called.
+  float next() { assert(false && "Should not be called"); }
+
+  // Return a diagonal of <1.0>s throughout the shape.
+  void fillData() override;
 };
 
 #endif // TPP_TRANSFORMS_UTILS_TENSORINITFLOAT_H

--- a/include/TPP/Transforms/Utils/TensorInitFloat.h
+++ b/include/TPP/Transforms/Utils/TensorInitFloat.h
@@ -85,14 +85,14 @@ protected:
   virtual void fillData() override = 0;
 };
 
-// Constant init (all-ones, do not use!).
+// Constant init (all-ones).
 struct ConstantTensorInitFloat : TensorInitFloat {
   ConstantTensorInitFloat(DataType type) : TensorInitFloat(type) {}
 
   // Return a dense<1.0> repeated throughout the shape.
   mlir::FailureOr<mlir::DenseElementsAttr> get(mlir::ShapedType shape) override;
 
-  void fillData() override;
+  void fillData() override { assert(false && "Should not be called"); }
 };
 
 // Random init (uniform).

--- a/include/TPP/Transforms/Utils/TensorInitInt.h
+++ b/include/TPP/Transforms/Utils/TensorInitInt.h
@@ -79,32 +79,9 @@ struct ConstantTensorInitInt : TensorInitInt {
   ConstantTensorInitInt(DataType type) : TensorInitInt(type) {}
 
   // Return a dense<1> repeated throughout the shape.
-  mlir::DenseElementsAttr get(mlir::ShapedType shape) override;
+  mlir::FailureOr<mlir::DenseElementsAttr> get(mlir::ShapedType shape) override;
 
   void fillData() override;
-};
-
-// Simple init (basic example, not useful).
-struct SimpleTensorInitInt : TensorInitInt {
-  SimpleTensorInitInt(DataType type) : TensorInitInt(type) {}
-
-  // Return a dense<0, 1, 2> repeated throughout the shape.
-  void fillData() override;
-};
-
-// Continuous init (quantized normalized affine range).
-struct ContinuousTensorInitInt : TensorInitInt {
-  ContinuousTensorInitInt(DataType type)
-      : TensorInitInt(type), upperBound(255) {
-    if (type == DataType::I8)
-      upperBound = 127;
-  }
-
-  // Return a dense<0 ... upperBound> throughout the shape.
-  void fillData() override;
-
-  // Upper bound for quantization.
-  int upperBound;
 };
 
 // Random init (uniform).
@@ -150,6 +127,26 @@ private:
   std::default_random_engine generator;
   // Random distribution.
   std::binomial_distribution<uint64_t> distribution;
+};
+
+// Identity init.
+struct IdentityTensorInitInt : TensorInitInt {
+  IdentityTensorInitInt(DataType type)
+      : TensorInitInt(type) {}
+
+  // Makes sure the shape is "square"
+  bool checkShape(mlir::ShapedType shape) override {
+    if (!TensorInit::checkShape(shape))
+      return false;
+    // Now the fields are set, compare all dims to be equal, 2D only for now
+    return dims.size() == 2 && dims[0] == dims[1];
+  }
+
+  // Should not be called.
+  float next() { assert(false && "Should not be called"); }
+
+  // Return a diagonal of <1.0>s throughout the shape.
+  void fillData() override;
 };
 
 #endif // TPP_TRANSFORMS_UTILS_TENSORINITINT_H

--- a/include/TPP/Transforms/Utils/TensorInitInt.h
+++ b/include/TPP/Transforms/Utils/TensorInitInt.h
@@ -74,14 +74,14 @@ protected:
   virtual void fillData() override = 0;
 };
 
-// Constant init (all-ones, do not use!).
+// Constant init (all-ones).
 struct ConstantTensorInitInt : TensorInitInt {
   ConstantTensorInitInt(DataType type) : TensorInitInt(type) {}
 
   // Return a dense<1> repeated throughout the shape.
   mlir::FailureOr<mlir::DenseElementsAttr> get(mlir::ShapedType shape) override;
 
-  void fillData() override;
+  void fillData() override { assert(false && "Should not be called"); }
 };
 
 // Random init (uniform).

--- a/lib/TPP/Runner/MLIRBench.cpp
+++ b/lib/TPP/Runner/MLIRBench.cpp
@@ -113,7 +113,7 @@ LogicalResult MLIRBench::replaceSplatWithRandom() {
     return module.emitError("No seed for random init");
 
   // Only replace attribute if it's a dense splat
-  auto replaceSplat = [&](ShapedType shape, Attribute attr) -> Attribute {
+  auto replaceSplat = [&](ShapedType shape, Attribute attr) -> FailureOr<Attribute> {
     // We only change dense attributes that are splat
     auto value = dyn_cast<DenseElementsAttr>(attr);
     if (!value || !value.isSplat())
@@ -145,7 +145,9 @@ LogicalResult MLIRBench::replaceSplatWithRandom() {
     if (!global)
       continue;
     auto newAttr = replaceSplat(global.getType(), global.getInitialValueAttr());
-    global.setInitialValueAttr(newAttr);
+    if (failed(newAttr))
+      return failure();
+    global.setInitialValueAttr(newAttr.value());
   }
 
   // Tensors are arith.constant values
@@ -157,7 +159,9 @@ LogicalResult MLIRBench::replaceSplatWithRandom() {
     if (!cstType)
       continue;
     auto newAttr = replaceSplat(cstType, constant.getValueAttr());
-    constant.setValueAttr(cast<TypedAttr>(newAttr));
+    if (failed(newAttr))
+      return failure();
+    constant.setValueAttr(cast<TypedAttr>(newAttr.value()));
   }
 
   return success();

--- a/lib/TPP/Runner/MLIRBench.cpp
+++ b/lib/TPP/Runner/MLIRBench.cpp
@@ -227,7 +227,7 @@ LogicalResult MLIRBench::createKernelArgs() {
           shape.getDimSize(0) == shape.getDimSize(1)) {
         argInitType = TensorInitType::Identity;
       } else {
-        return failure();
+        return module.emitError("Invalid shape for identity init");
       }
     }
     auto arg =
@@ -255,7 +255,7 @@ LogicalResult MLIRBench::createKernelArgs() {
             .Default([&](auto t) { return std::nullopt; });
 
     if (!arg)
-      return failure();
+      return module.emitError("Cannot create kernel argument");
 
     kernelArgs.push_back(*arg);
     argNum++;

--- a/lib/TPP/Runner/MLIRBench.cpp
+++ b/lib/TPP/Runner/MLIRBench.cpp
@@ -56,6 +56,7 @@ using namespace mlir;
 MLIRBench::MLIRBench(mlir::Operation *op, const MLIRBenchConfig &config)
     : builder(op->getContext()), unkLoc(builder.getUnknownLoc()) {
   seed = config.seed;
+  identity = config.identity;
   backend = config.backend;
   initType = config.initType;
   offloadToDevice = config.offloadToDevice;
@@ -216,34 +217,48 @@ LogicalResult MLIRBench::createKernelArgs() {
   auto &mainBody = getMainBlock();
   builder.setInsertionPointToStart(&mainBody);
 
+  int argNum = 0;
   for (auto &ty : kernel.getArgumentTypes()) {
-    auto arg = TypeSwitch<Type, std::optional<Value>>(ty)
-                   .Case<MemRefType>([&](auto memRefTy) {
-                     // Create a memref global
-                     Value data = createDenseMemref(builder, module, initType,
-                                                    memRefTy, seed);
-                     data = registerOnGpu(data, memRefTy);
-                     return data;
-                   })
-                   .Case<TensorType>([&](auto tensorTy) {
-                     // Create a memref global and cast it to a tensor
-                     // to ensure that the buffer is writable and
-                     // bufferization does not insert extra
-                     // allocations + copies
-                     auto memrefType = MemRefType::get(
-                         tensorTy.getShape(), tensorTy.getElementType());
-                     auto data = createDenseMemref(builder, module, initType,
-                                                   memrefType, seed);
-                     data = registerOnGpu(data, memrefType);
-                     return builder.create<bufferization::ToTensorOp>(
-                         unkLoc, tensorTy, data, /*restrict=*/true, /*writable=*/true);
-                   })
-                   .Default([&](auto t) { return std::nullopt; });
+    auto argInitType = initType;
+    // Requested an argument to be identity, must be 2D square
+    if (argNum == identity) {
+      ShapedType shape = dyn_cast<ShapedType>(ty);
+      if (shape && shape.getRank() == 2 &&
+          shape.getDimSize(0) == shape.getDimSize(1)) {
+        argInitType = TensorInitType::Identity;
+      } else {
+        return failure();
+      }
+    }
+    auto arg =
+        TypeSwitch<Type, std::optional<Value>>(ty)
+            .Case<MemRefType>([&](auto memRefTy) {
+              // Create a memref global
+              Value data = createDenseMemref(builder, module, argInitType,
+                                             memRefTy, seed);
+              data = registerOnGpu(data, memRefTy);
+              return data;
+            })
+            .Case<TensorType>([&](auto tensorTy) {
+              // Create a memref global and cast it to a tensor
+              // to ensure that the buffer is writable and
+              // bufferization does not insert extra
+              // allocations + copies
+              auto memrefType = MemRefType::get(tensorTy.getShape(),
+                                                tensorTy.getElementType());
+              auto data = createDenseMemref(builder, module, argInitType,
+                                            memrefType, seed);
+              data = registerOnGpu(data, memrefType);
+              return builder.create<bufferization::ToTensorOp>(
+                  unkLoc, tensorTy, data, /*restrict=*/true, /*writable=*/true);
+            })
+            .Default([&](auto t) { return std::nullopt; });
 
     if (!arg)
       return failure();
 
     kernelArgs.push_back(*arg);
+    argNum++;
   }
 
   return success();

--- a/lib/TPP/Runner/TppRunnerWrapper.cpp
+++ b/lib/TPP/Runner/TppRunnerWrapper.cpp
@@ -56,7 +56,7 @@ struct TppRunnerWrapper
     }
 
     // Benchmark object.
-    MLIRBenchConfig config(seed, tensorInitType, backend, offloadToDevice);
+    MLIRBenchConfig config(seed, tensorInitType, identity, backend, offloadToDevice);
     MLIRBench bench(module, config);
 
     // Can only either print or run benchmarks, make this clear before we try to

--- a/lib/TPP/Transforms/Utils/BuilderUtils.cpp
+++ b/lib/TPP/Transforms/Utils/BuilderUtils.cpp
@@ -79,7 +79,8 @@ Value createDenseTensor(OpBuilder &builder, TensorInitType initType,
   auto unkLoc = builder.getUnknownLoc();
   auto init = getTensorInit(initType, type.getElementType(), seed);
   auto floatInit = init->get(type);
-  return builder.create<arith::ConstantOp>(unkLoc, type, floatInit);
+  assert(!failed(floatInit) && "Invalid dense tensor initializer");
+  return builder.create<arith::ConstantOp>(unkLoc, type, floatInit.value());
 }
 
 Value createDenseMemref(OpBuilder &builder, ModuleOp module,
@@ -103,10 +104,11 @@ Value createDenseMemref(OpBuilder &builder, ModuleOp module,
     auto alignment = builder.getIntegerAttr(builder.getI64Type(), 128);
     auto init = getTensorInit(initType, type.getElementType(), seed);
     auto floatInit = init->get(type);
+    assert(!failed(floatInit) && "Invalid dense tensor initializer");
 
     // Create the global object in the Module's region
     auto global = builder.create<memref::GlobalOp>(
-        unkLoc, StringRef(name), privAttr, type, floatInit,
+        unkLoc, StringRef(name), privAttr, type, floatInit.value(),
         /*constant=*/false, alignment);
     globalName = global.getName();
   }

--- a/lib/TPP/Transforms/Utils/TensorInit.cpp
+++ b/lib/TPP/Transforms/Utils/TensorInit.cpp
@@ -64,10 +64,9 @@ TensorInitType parseTensorInitType(StringRef name) {
   auto type = StringSwitch<TensorInitType>(name)
                   .Case("", TensorInitType::Auto)
                   .Case("const", TensorInitType::Constant)
-                  .Case("simple", TensorInitType::Simple)
-                  .Case("cont", TensorInitType::Continuous)
                   .Case("random", TensorInitType::Random)
                   .Case("normal", TensorInitType::Normal)
+                  .Case("identity", TensorInitType::Identity)
                   .Default(TensorInitType::Invalid);
   return type;
 }
@@ -93,12 +92,6 @@ TensorInitPtr getTensorInit(TensorInitType type, mlir::Type elmType, int seed) {
     case TensorInitType::Constant:
       initPtr = std::make_shared<ConstantTensorInitFloat>(dataType);
       break;
-    case TensorInitType::Simple:
-      initPtr = std::make_shared<SimpleTensorInitFloat>(dataType);
-      break;
-    case TensorInitType::Continuous:
-      initPtr = std::make_shared<ContinuousTensorInitFloat>(dataType);
-      break;
     case TensorInitType::Random:
       assert(seed && "Can't call random initializers without seed");
       initPtr = std::make_shared<RandomTensorInitFloat>(dataType, seed);
@@ -106,6 +99,9 @@ TensorInitPtr getTensorInit(TensorInitType type, mlir::Type elmType, int seed) {
     case TensorInitType::Normal:
       assert(seed && "Can't call random initializers without seed");
       initPtr = std::make_shared<NormalTensorInitFloat>(dataType, seed);
+      break;
+    case TensorInitType::Identity:
+      initPtr = std::make_shared<IdentityTensorInitFloat>(dataType);
       break;
     default:
       assert(false && "Invalid tensor initializer type");
@@ -118,12 +114,6 @@ TensorInitPtr getTensorInit(TensorInitType type, mlir::Type elmType, int seed) {
     case TensorInitType::Constant:
       initPtr = std::make_shared<ConstantTensorInitInt>(dataType);
       break;
-    case TensorInitType::Simple:
-      initPtr = std::make_shared<SimpleTensorInitInt>(dataType);
-      break;
-    case TensorInitType::Continuous:
-      initPtr = std::make_shared<ContinuousTensorInitInt>(dataType);
-      break;
     case TensorInitType::Random:
       assert(seed && "Can't call random initializers without seed");
       initPtr = std::make_shared<RandomTensorInitInt>(dataType, seed);
@@ -131,6 +121,9 @@ TensorInitPtr getTensorInit(TensorInitType type, mlir::Type elmType, int seed) {
     case TensorInitType::Normal:
       assert(seed && "Can't call random initializers without seed");
       initPtr = std::make_shared<NormalTensorInitInt>(dataType, seed);
+      break;
+    case TensorInitType::Identity:
+      initPtr = std::make_shared<IdentityTensorInitInt>(dataType);
       break;
     default:
       assert(false && "Invalid tensor initializer type");

--- a/lib/TPP/Transforms/Utils/TensorInit.cpp
+++ b/lib/TPP/Transforms/Utils/TensorInit.cpp
@@ -140,3 +140,14 @@ TensorInitPtr getTensorInit(StringRef type, mlir::Type elmType, int seed) {
   auto initType = parseTensorInitType(type);
   return getTensorInit(initType, elmType, seed);
 }
+
+FailureOr<int> getIdentityOption(StringRef identity) {
+  int option = StringSwitch<int>(identity)
+                   .Case("", -1)
+                   .CaseLower("a", 0)
+                   .CaseLower("b", 1)
+                   .Default(-2);
+  if (option == -2)
+    return failure();
+  return option;
+}

--- a/lib/TPP/Transforms/Utils/TensorInit.cpp
+++ b/lib/TPP/Transforms/Utils/TensorInit.cpp
@@ -140,14 +140,3 @@ TensorInitPtr getTensorInit(StringRef type, mlir::Type elmType, int seed) {
   auto initType = parseTensorInitType(type);
   return getTensorInit(initType, elmType, seed);
 }
-
-FailureOr<int> getIdentityOption(StringRef identity) {
-  int option = StringSwitch<int>(identity)
-                   .Case("", -1)
-                   .CaseLower("a", 0)
-                   .CaseLower("b", 1)
-                   .Default(-2);
-  if (option == -2)
-    return failure();
-  return option;
-}

--- a/lib/TPP/Transforms/Utils/TensorInitFloat.cpp
+++ b/lib/TPP/Transforms/Utils/TensorInitFloat.cpp
@@ -51,7 +51,7 @@ void TensorInitFloat::convertType(llvm::APFloat &value) {
   }
 }
 
-DenseElementsAttr ConstantTensorInitFloat::get(ShapedType shape) {
+FailureOr<DenseElementsAttr> ConstantTensorInitFloat::get(ShapedType shape) {
   auto floatValue = APFloat(1.0F);
   if (!isTypeSupported(shape.getElementType()))
     assert(false && "Element type not supported");
@@ -68,20 +68,6 @@ void ConstantTensorInitFloat::fillData() {
   assert(false && "Should not be called");
 }
 
-void SimpleTensorInitFloat::fillData() {
-  assert(buffer.size() == 0 && "Buffer not empty");
-  float data[3] = {0.3f, 0.6f, 0.9f};
-  for (size_t i = 0; i < size; i++)
-    push(data[i % 3]);
-}
-
-void ContinuousTensorInitFloat::fillData() {
-  assert(buffer.size() == 0 && "Buffer not empty");
-  float normFactor = static_cast<float>(size);
-  for (size_t i = 0; i < size; i++)
-    push(static_cast<float>(i) / normFactor);
-}
-
 void RandomTensorInitFloat::fillData() {
   assert(buffer.size() == 0 && "Buffer not empty");
   for (size_t i = 0; i < size; i++)
@@ -92,4 +78,18 @@ void NormalTensorInitFloat::fillData() {
   assert(buffer.size() == 0 && "Buffer not empty");
   for (size_t i = 0; i < size; i++)
     push(next());
+}
+
+void IdentityTensorInitFloat::fillData() {
+  assert(buffer.size() == 0 && "Buffer not empty");
+  APFloat zero = APFloat(0.0);
+  convertType(zero);
+  buffer.resize(size, zero);
+  size_t ld = dims[0];
+
+  // Shape is guaranteed to be "2D square" by `checkShape()`
+  for (size_t i=0; i < ld; i++) {
+    size_t offset = i*ld + i;
+    insert(offset, APFloat(1.0));
+  }
 }

--- a/lib/TPP/Transforms/Utils/TensorInitFloat.cpp
+++ b/lib/TPP/Transforms/Utils/TensorInitFloat.cpp
@@ -64,10 +64,6 @@ FailureOr<DenseElementsAttr> ConstantTensorInitFloat::get(ShapedType shape) {
   return mlir::DenseElementsAttr::get(tensorType, floatValue);
 }
 
-void ConstantTensorInitFloat::fillData() {
-  assert(false && "Should not be called");
-}
-
 void RandomTensorInitFloat::fillData() {
   assert(buffer.size() == 0 && "Buffer not empty");
   for (size_t i = 0; i < size; i++)

--- a/lib/TPP/Transforms/Utils/TensorInitInt.cpp
+++ b/lib/TPP/Transforms/Utils/TensorInitInt.cpp
@@ -62,7 +62,7 @@ void TensorInitInt::convertType(llvm::APInt &value) {
   assert(value.getBitWidth() == bitWidth && "Invalid element size");
 }
 
-DenseElementsAttr ConstantTensorInitInt::get(ShapedType shape) {
+FailureOr<DenseElementsAttr> ConstantTensorInitInt::get(ShapedType shape) {
   auto value = APInt(bitWidth, 1, isSigned);
   if (!isTypeSupported(shape.getElementType()))
     assert(false && "Element type not supported");
@@ -79,21 +79,6 @@ void ConstantTensorInitInt::fillData() {
   assert(false && "Should not be called");
 }
 
-void SimpleTensorInitInt::fillData() {
-  assert(buffer.size() == 0 && "Buffer not empty");
-  uint64_t data[3] = {0, 1, 2};
-  for (size_t i = 0; i < size; i++)
-    push(data[i % 3]);
-}
-
-void ContinuousTensorInitInt::fillData() {
-  assert(buffer.size() == 0 && "Buffer not empty");
-  float normFactor = static_cast<float>(size);
-  for (size_t i = 0; i < size; i++)
-    push(static_cast<uint64_t>((static_cast<float>(i) / normFactor) *
-                               upperBound));
-}
-
 void RandomTensorInitInt::fillData() {
   assert(buffer.size() == 0 && "Buffer not empty");
   for (size_t i = 0; i < size; i++)
@@ -104,4 +89,18 @@ void NormalTensorInitInt::fillData() {
   assert(buffer.size() == 0 && "Buffer not empty");
   for (size_t i = 0; i < size; i++)
     push(next());
+}
+
+void IdentityTensorInitInt::fillData() {
+  assert(buffer.size() == 0 && "Buffer not empty");
+  APInt zero = APInt(bitWidth, 0, isSigned);
+  convertType(zero);
+  buffer.resize(size, zero);
+  size_t ld = dims[0];
+
+  // Shape is guaranteed to be "2D square" by `checkShape()`
+  for (size_t i=0; i < ld; i++) {
+    size_t offset = i*ld + i;
+    insert(offset, APInt(bitWidth, 1, isSigned));
+  }
 }

--- a/lib/TPP/Transforms/Utils/TensorInitInt.cpp
+++ b/lib/TPP/Transforms/Utils/TensorInitInt.cpp
@@ -75,10 +75,6 @@ FailureOr<DenseElementsAttr> ConstantTensorInitInt::get(ShapedType shape) {
   return mlir::DenseElementsAttr::get(tensorType, value);
 }
 
-void ConstantTensorInitInt::fillData() {
-  assert(false && "Should not be called");
-}
-
 void RandomTensorInitInt::fillData() {
   assert(buffer.size() == 0 && "Buffer not empty");
   for (size_t i = 0; i < size; i++)

--- a/test/Integration/mlir-gen.mlir
+++ b/test/Integration/mlir-gen.mlir
@@ -7,6 +7,9 @@
 // MLP without softmax
 // RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10,10 | tpp-run -e entry -entry-point-result=void
 
+// MLP with identity
+// RUN: mlir-gen --kernel=const --identity --bias --relu --seed=123 --batch=10 --layers=10,10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=IDENTITY 
+
 // Matmul only
 // RUN: mlir-gen --kernel=const --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=MATMUL
 // RUN: mlir-gen --kernel=const --batch=10 --layers=10,10 --output=generic | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=MATMUL
@@ -30,6 +33,8 @@
 // Packed versions
 // RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
 // RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+
+// IDENTITY:( 3, 3, 3, 3, 3, 3, 3, 3, 3, 3 )
 
 // MATMUL:( 10, 10, 10, 10, 10, 10, 10, 10, 10, 10 )
 

--- a/test/Integration/mlir-gen.mlir
+++ b/test/Integration/mlir-gen.mlir
@@ -8,7 +8,8 @@
 // RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10,10 | tpp-run -e entry -entry-point-result=void
 
 // MLP with identity
-// RUN: mlir-gen --kernel=const --identity --bias --relu --seed=123 --batch=10 --layers=10,10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=IDENTITY 
+// RUN: mlir-gen --kernel=const --identity --seed=0 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=IDENTITY_CONST
+// RUN: mlir-gen --kernel=args --seed=0 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print -identity=1 | FileCheck %s --check-prefix=IDENTITY_ARGS
 
 // Matmul only
 // RUN: mlir-gen --kernel=const --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=MATMUL
@@ -34,7 +35,11 @@
 // RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
 // RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
 
-// IDENTITY:( 3, 3, 3, 3, 3, 3, 3, 3, 3, 3 )
+// Implements C = A*B, with A=1, B=ID
+// IDENTITY_CONST:( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 )
+
+// Implements C += A*B, with A=1, B=ID, C=1
+// IDENTITY_ARGS:( 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 )
 
 // MATMUL:( 10, 10, 10, 10, 10, 10, 10, 10, 10, 10 )
 

--- a/test/Integration/tpp-run-splat-identity.mlir
+++ b/test/Integration/tpp-run-splat-identity.mlir
@@ -1,0 +1,22 @@
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=identity 2>&1 | \
+// RUN: FileCheck %s
+
+func.func @entry(%arg0: tensor<2x2xi32>) {
+  %0 = arith.constant dense<2.0> : tensor<1x1xbf16>
+  %1 = arith.constant dense<0.0> : tensor<4x4xf32>
+  %2 = arith.constant dense<1.0> : tensor<4x4xf32>
+  return
+}
+
+// Integer identity of the argument goes into a global variable.
+// CHECK: memref.global "private" @__wrapper_0 : memref<2x2xi32> = dense<{{.}}[1, 0], [0, 1]{{.}}> {alignment = 128 : i64}
+// CHECK-LABEL: @_entry
+// Dense non-zero identity (changes 2.0 to 1.0)
+// CHECK: arith.constant dense<1.000000e+00> : tensor<1x1xbf16>
+// Dense zero identity does not change (remains 0.0)
+// CHECK: arith.constant dense<0.000000e+00> : tensor<4x4xf32>
+// Dense non-zero identity (4x4 identity matrix)
+// CHECK: arith.constant dense<{{.}}[1.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00],
+// CHECK-SAME:                      [0.000000e+00, 1.000000e+00, 0.000000e+00, 0.000000e+00],
+// CHECK-SAME:                      [0.000000e+00, 0.000000e+00, 1.000000e+00, 0.000000e+00],
+// CHECK-SAME:                      [0.000000e+00, 0.000000e+00, 0.000000e+00, 1.000000e+00]{{.}}> : tensor<4x4xf32>

--- a/test/Integration/tpp-run-splat-tensor.mlir
+++ b/test/Integration/tpp-run-splat-tensor.mlir
@@ -8,10 +8,6 @@
 // Options for -init-type
 // RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=const 2>&1 | \
 // RUN: FileCheck %s --check-prefix=OPT-CONST
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=simple 2>&1 | \
-// RUN: FileCheck %s --check-prefix=OPT-SIMPLE
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=cont 2>&1 | \
-// RUN: FileCheck %s --check-prefix=OPT-CONT
 // RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=random 2>&1 | \
 // RUN: FileCheck %s --check-prefix=OPT-RANDOM
 // RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=normal 2>&1 | \
@@ -133,44 +129,6 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>, %arg2: tensor<4
 // OPT-CONST: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
 // OPT-CONST: arith.constant 1.000000e+00 : f32
 // OPT-CONST: arith.constant dense<1.000000e+00> : tensor<4x8xf16>
-
-// OPT-SIMPLE-LABEL: @_entry
-// OPT-SIMPLE: arith.constant dense<{{.*}}3.000000e-01, 6.000000e-01, 0.899999976, {{.*}}> : tensor<2x16xf32>
-// OPT-SIMPLE: arith.constant dense<{{.*}}0.30000001192092896, 0.60000002384185791, 0.89999997615814208, {{.*}}> : tensor<2x16xf64>
-// OPT-SIMPLE: arith.constant dense<{{.*}}3.000000e-01, 6.000000e-01, 0.899999976, {{.*}}> : tensor<4x16xf32>
-// OPT-SIMPLE: arith.constant dense<{{.*}}3.000000e-01, 6.000000e-01, 0.899999976, {{.*}}> : tensor<4x4xf32>
-// OPT-SIMPLE: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
-// OPT-SIMPLE: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
-// OPT-SIMPLE-NOT: arith.constant dense<1> : tensor<4x2xi8>
-// OPT-SIMPLE: arith.constant dense<{{\[}}{{\[}}0, 1{{.*}}> : tensor<4x2xi8>
-// OPT-SIMPLE: arith.constant dense<0> : tensor<4x8xi32>
-// OPT-SIMPLE-NOT: arith.constant dense<1> : tensor<4x8xi32>
-// OPT-SIMPLE-NOT: arith.constant dense<1> : tensor<4x8xi64>
-// OPT-SIMPLE: arith.constant dense<{{\[}}{{\[}}0, 1, 2, 0, 1, 2{{.*}}> : tensor<4x8xi32>
-// OPT-SIMPLE: arith.constant dense<{{\[}}{{\[}}0, 1, 2, 0, 1, 2{{.*}}> : tensor<4x8xi32>
-// OPT-SIMPLE: arith.constant dense<{{\[}}{{\[}}0, 1, 2, 0, 1, 2{{.*}}> : tensor<4x8xi64>
-// OPT-SIMPLE: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
-// OPT-SIMPLE: arith.constant 1.000000e+00 : f32
-// OPT-SIMPLE: arith.constant dense<{{.*}}3.000490e-01, 6.000980e-01, 8.999020e-01, {{.*}}> : tensor<4x8xf16>
-
-// OPT-CONT-LABEL: @_entry
-// OPT-CONT: arith.constant dense<{{.*}}0.000000e+00, 3.125000e-02, 6.250000e-02, {{.*}}> : tensor<2x16xf32>
-// OPT-CONT: arith.constant dense<{{.*}}0.000000e+00, 3.125000e-02, 6.250000e-02, {{.*}}> : tensor<2x16xf64>
-// OPT-CONT: arith.constant dense<{{.*}}0.000000e+00, 1.562500e-02, 3.125000e-02,  {{.*}}> : tensor<4x16xf32>
-// OPT-CONT: arith.constant dense<{{.*}}0.000000e+00, 6.250000e-02, 1.250000e-01,  {{.*}}> : tensor<4x4xf32>
-// OPT-CONT: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
-// OPT-CONT: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
-// OPT-CONT-NOT: arith.constant dense<1> : tensor<4x2xi8>
-// OPT-CONT: arith.constant dense<{{\[}}{{\[}}0, 15{{.*}}> : tensor<4x2xi8>
-// OPT-CONT: arith.constant dense<0> : tensor<4x8xi32>
-// OPT-CONT-NOT: arith.constant dense<1> : tensor<4x8xi32>
-// OPT-CONT-NOT: arith.constant dense<1> : tensor<4x8xi64>
-// OPT-CONT: arith.constant dense<{{\[}}{{\[}}0, 7, 15, 23, 31{{.*}}> : tensor<4x8xi32>
-// OPT-CONT: arith.constant dense<{{\[}}{{\[}}0, 7, 15, 23, 31{{.*}}> : tensor<4x8xi32>
-// OPT-CONT: arith.constant dense<{{\[}}{{\[}}0, 7, 15, 23, 31{{.*}}> : tensor<4x8xi64>
-// OPT-CONT: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
-// OPT-CONT: arith.constant 1.000000e+00 : f32
-// OPT-CONT: arith.constant dense<{{.*}}0.000000e+00, 3.125000e-02, 6.250000e-02, {{.*}}> : tensor<4x8xf16>
 
 // OPT-RANDOM-LABEL: @_entry
 // OPT-RANDOM: arith.constant dense<{{.*}}9.62642952E-4, 0.179147944, 0.939454615, {{.*}}> : tensor<2x16xf32>

--- a/tools/mlir-gen/MLIRGen.h
+++ b/tools/mlir-gen/MLIRGen.h
@@ -57,6 +57,9 @@ class MLIRGenerator {
   /// Random seed
   int seed;
 
+  /// Identity weights
+  bool identity;
+
   /// Generated model's flops
   int64_t flops;
 
@@ -226,7 +229,7 @@ public:
   /// so should create new objects to not have to share / cleanup existing MLIR
   /// modules.
   MLIRGenerator(StringRef, StringRef, unsigned, StringRef, StringRef, StringRef,
-                int, bool, bool, bool, bool, int);
+                int, bool, bool, bool, bool, bool, int);
 
   ~MLIRGenerator() { module->destroy(); }
 

--- a/tools/mlir-gen/mlir-gen.cpp
+++ b/tools/mlir-gen/mlir-gen.cpp
@@ -75,6 +75,14 @@ llvm::cl::opt<std::string>
 llvm::cl::opt<int> seed("seed", llvm::cl::desc("Random seed"),
                         llvm::cl::value_desc("int"), llvm::cl::init(0));
 
+// Identity matrix
+// Replace single square argument with identity matrix
+// Note: Must have two arguments and the selected must be square
+llvm::cl::opt<bool> identity("identity",
+                             llvm::cl::desc("Identity matrix on weight (bias 1s)"),
+                             llvm::cl::value_desc("bool"),
+                             llvm::cl::init(false));
+
 // Output filename
 llvm::cl::opt<std::string> filename("o", llvm::cl::desc("Output filename"),
                                     llvm::cl::value_desc("stdout"),
@@ -112,7 +120,7 @@ int main(int argc, char **argv) {
   llvm::cl::ParseCommandLineOptions(argc, argv, "MLIR Generator");
 
   MLIRGenerator gen(outputOpKind, kernel, batch, layers, tiles, floatType, seed,
-                    enableBias, enableRelu, enableSoftmax, keepGenericMatmul,
-                    vnni);
+                    identity, enableBias, enableRelu, enableSoftmax,
+                    keepGenericMatmul, vnni);
   return gen.generate(filename);
 }

--- a/tools/tpp-run/tpp-run.cpp
+++ b/tools/tpp-run/tpp-run.cpp
@@ -95,10 +95,10 @@ llvm::cl::opt<std::string> initType(
 // Identity matrix
 // Replace single square argument with identity matrix
 // Note: Must have two arguments and the selected must be square
-llvm::cl::opt<std::string> identity(
+llvm::cl::opt<int> identity(
     "identity",
-    llvm::cl::desc("Identity matrix on one argument (a, b)"),
-    llvm::cl::init(""));
+    llvm::cl::desc("Identity matrix on one argument (-1=none, 0=a, 1=b, ...)"),
+    llvm::cl::init(-1));
 
 // Speed optimization level
 llvm::cl::opt<unsigned>
@@ -183,10 +183,6 @@ static LogicalResult prepareMLIRKernel(Operation *op,
   if (failed(applyPassManagerCLOptions(passManager)))
     return failure();
 
-  auto id = getIdentityOption(identity);
-  if (failed(id))
-    return failure();
-
   tpp::TppRunnerWrapperOptions wrapperOpts;
   wrapperOpts.kernelName = options.mainFuncName;
   wrapperOpts.kernelType = options.mainFuncType;
@@ -200,7 +196,7 @@ static LogicalResult prepareMLIRKernel(Operation *op,
   wrapperOpts.randomSplat = splatRandom;
   wrapperOpts.seed = seed;
   wrapperOpts.initType = initType;
-  wrapperOpts.identity = id.value();
+  wrapperOpts.identity = identity;
   passManager.addPass(tpp::createTppRunnerWrapper(wrapperOpts));
 
   tpp::DefaultPipelineOptions defPipelineOpts{defGpuBackend,

--- a/tools/tpp-run/tpp-run.cpp
+++ b/tools/tpp-run/tpp-run.cpp
@@ -168,17 +168,6 @@ TargetMachineOptions getTargetMachineOptions(StringRef option) {
       .Default({defaultTriple, defaultCpu, defaultFeature});
 }
 
-FailureOr<int> getIdentityOption() {
-  int option = StringSwitch<int>(identity)
-                   .Case("", -1)
-                   .CaseLower("a", 0)
-                   .CaseLower("b", 1)
-                   .Default(-2);
-  if (option == -2)
-    return failure();
-  return option;
-}
-
 // This function will be called by the pass manager after parsing,
 // so we can modify the IR with the needed wrappers
 static LogicalResult prepareMLIRKernel(Operation *op,
@@ -194,7 +183,7 @@ static LogicalResult prepareMLIRKernel(Operation *op,
   if (failed(applyPassManagerCLOptions(passManager)))
     return failure();
 
-  auto id = getIdentityOption();
+  auto id = getIdentityOption(identity);
   if (failed(id))
     return failure();
 

--- a/tools/tpp-run/tpp-run.cpp
+++ b/tools/tpp-run/tpp-run.cpp
@@ -89,7 +89,7 @@ llvm::cl::opt<int> seed("seed",
 // Default const if seed == 0, and normal otherwise
 llvm::cl::opt<std::string> initType(
     "init-type",
-    llvm::cl::desc("Initializer type (const, simple, cont, rand, normal)"),
+    llvm::cl::desc("Initializer type (const, rand, normal)"),
     llvm::cl::init(""));
 
 // Identity matrix

--- a/tools/tpp-run/tpp-run.cpp
+++ b/tools/tpp-run/tpp-run.cpp
@@ -168,6 +168,17 @@ TargetMachineOptions getTargetMachineOptions(StringRef option) {
       .Default({defaultTriple, defaultCpu, defaultFeature});
 }
 
+FailureOr<int> getIdentityOption() {
+  int option = StringSwitch<int>(identity)
+                   .Case("", -1)
+                   .CaseLower("a", 0)
+                   .CaseLower("b", 1)
+                   .Default(-2);
+  if (option == -2)
+    return failure();
+  return option;
+}
+
 // This function will be called by the pass manager after parsing,
 // so we can modify the IR with the needed wrappers
 static LogicalResult prepareMLIRKernel(Operation *op,
@@ -183,6 +194,10 @@ static LogicalResult prepareMLIRKernel(Operation *op,
   if (failed(applyPassManagerCLOptions(passManager)))
     return failure();
 
+  auto id = getIdentityOption();
+  if (failed(id))
+    return failure();
+
   tpp::TppRunnerWrapperOptions wrapperOpts;
   wrapperOpts.kernelName = options.mainFuncName;
   wrapperOpts.kernelType = options.mainFuncType;
@@ -196,7 +211,7 @@ static LogicalResult prepareMLIRKernel(Operation *op,
   wrapperOpts.randomSplat = splatRandom;
   wrapperOpts.seed = seed;
   wrapperOpts.initType = initType;
-  wrapperOpts.identity = identity;
+  wrapperOpts.identity = id.value();
   passManager.addPass(tpp::createTppRunnerWrapper(wrapperOpts));
 
   tpp::DefaultPipelineOptions defPipelineOpts{defGpuBackend,

--- a/tools/tpp-run/tpp-run.cpp
+++ b/tools/tpp-run/tpp-run.cpp
@@ -85,17 +85,25 @@ llvm::cl::opt<int> seed("seed",
                         llvm::cl::desc("Random seed, default 0 (no random)"),
                         llvm::cl::value_desc("int"), llvm::cl::init(0));
 
-// Speed optimization level
-llvm::cl::opt<unsigned>
-    optLevel("O", llvm::cl::desc("Speed optimization level (O0, O1, O2, O3)"),
-             llvm::cl::value_desc("0-3"), llvm::cl::init(2));
-
 // Initializer type
 // Default const if seed == 0, and normal otherwise
 llvm::cl::opt<std::string> initType(
     "init-type",
     llvm::cl::desc("Initializer type (const, simple, cont, rand, normal)"),
     llvm::cl::init(""));
+
+// Identity matrix
+// Replace single square argument with identity matrix
+// Note: Must have two arguments and the selected must be square
+llvm::cl::opt<std::string> identity(
+    "identity",
+    llvm::cl::desc("Identity matrix on one argument (a, b)"),
+    llvm::cl::init(""));
+
+// Speed optimization level
+llvm::cl::opt<unsigned>
+    optLevel("O", llvm::cl::desc("Speed optimization level (O0, O1, O2, O3)"),
+             llvm::cl::value_desc("0-3"), llvm::cl::init(2));
 
 // Print LLVM IR before lowering
 llvm::cl::opt<bool> printLLVM("print-llvm",
@@ -188,6 +196,7 @@ static LogicalResult prepareMLIRKernel(Operation *op,
   wrapperOpts.randomSplat = splatRandom;
   wrapperOpts.seed = seed;
   wrapperOpts.initType = initType;
+  wrapperOpts.identity = identity;
   passManager.addPass(tpp::createTppRunnerWrapper(wrapperOpts));
 
   tpp::DefaultPipelineOptions defPipelineOpts{defGpuBackend,


### PR DESCRIPTION
This is a step towards allowing tests like A * I = A.

As is, it still doesn't do what we want, since like the others, it tried to initialize all tensors with identity, so any non square tensor will fail.

The next step is to add options like "--identity-b" together with "--splat-to-random", so that only the B matrix is replaced by identity.

Also remove some unused initializers.