### PR TITLE
[μKernels]: Micro-kernel lowering for splat bf16 - ARL

### DIFF
--- a/lib/TPP/Transforms/VectorContractToMicroKernels.cpp
+++ b/lib/TPP/Transforms/VectorContractToMicroKernels.cpp
@@ -1400,7 +1400,6 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
                             kForOp.getLoc(), matf32[i], shuffle,
                             iterArgsNewKForOp[(j / sizeFactor) +
                                               (i * (N / sizeFactor))]);
-                        // k++;
                         oddFMAs.push_back(fmaOdd);
                       }
 
@@ -1423,7 +1422,6 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
                           kForOp.getLoc(), matf32[i], evenB,
                           iterArgsNewKForOp[(j / sizeFactor) +
                                             (i * (N / sizeFactor))]);
-                      // k++;
                       oddFMAs.push_back(fmaOdd);
                     }
 
@@ -1441,7 +1439,6 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
                           kForOp.getLoc(), matf32[i], oddB,
                           iterArgsNewKForOp[((j + sizeFactor) / sizeFactor) +
                                             (i * (N / sizeFactor))]);
-                      // k++;
                       oddFMAs.push_back(fmaOdd);
                     }
                   }

--- a/lib/TPP/Transforms/VectorContractToMicroKernels.cpp
+++ b/lib/TPP/Transforms/VectorContractToMicroKernels.cpp
@@ -435,9 +435,9 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
       return rewriter.notifyMatchFailure(
           contractOp, "F16/I8 type is supported only for SRF kind of machines");
 
-    if (isSplat && !(bf16dp))
+    if (isSplat && !(bf16dp || srf))
       return rewriter.notifyMatchFailure(
-          contractOp, "Only Splat-bf16 avx512-dp lowering is supported");
+          contractOp, "Only Splat-bf16 avx512-dp + SRF lowering is supported");
 
     int64_t M = 0;
     int64_t N = 0;
@@ -476,7 +476,11 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
       K = lhsType.getDimSize(lhsType.getRank() - 1);
       vnni = vnniFactor;
 
-      if (K != vnni)
+      if (K != vnni && bf16dp)
+        return rewriter.notifyMatchFailure(
+            contractOp, "K tile size should be equal to vnni");
+
+      if (K != 1 && (srf || isF32))
         return rewriter.notifyMatchFailure(
             contractOp, "K tile size should be equal to one");
     }
@@ -605,10 +609,10 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
       for (int j = 0; j < N; j = j + sizeFactor) {
         for (int i = 0; i < M; i++) {
           auto zeroAttr = DenseElementsAttr::get(
-              VectorType::get({16}, rewriter.getF32Type()), 0.0f);
+              VectorType::get({sizeFactor}, rewriter.getF32Type()), 0.0f);
           auto cst = rewriter.create<arith::ConstantOp>(
               reductionForOp.getLoc(),
-              VectorType::get({16}, rewriter.getF32Type()), zeroAttr);
+              VectorType::get({sizeFactor}, rewriter.getF32Type()), zeroAttr);
           loopItrArgs.push_back(cst);
         }
       }
@@ -1329,15 +1333,136 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
                   }
                 }
 
+                if (isSplat && srf) {
+
+                  llvm::SmallVector<OpFoldResult> strides_splat = {
+                      rewriter.getIndexAttr(1), rewriter.getIndexAttr(1),
+                      rewriter.getIndexAttr(1)};
+                  llvm::SmallVector<OpFoldResult> sizes_splat = {
+                      rewriter.getIndexAttr(1), rewriter.getIndexAttr(1),
+                      rewriter.getIndexAttr(1)};
+
+                  for (int i = 0; i < M; i++) {
+                    Value oddA;
+
+                    SmallVector<OpFoldResult> offsets = {
+                        rewriter.getIndexAttr(0),
+                        rewriter.getIndexAttr(i),
+                        rewriter.getIndexAttr(0),
+                    };
+                    auto subview = rewriter.create<memref::SubViewOp>(
+                        kForOp.getLoc(), lhsClone->getResult(0), offsets,
+                        sizes_splat, strides_splat);
+                    oddA = rewriter.create<mlir::x86vector::BcstToPackedF32Op>(
+                        kForOp.getLoc(), dstType, subview);
+
+                    matf32.push_back(oddA);
+                  }
+
+                  // Load odd elements of B-Matrix, perform fma (odd), and store
+                  // to a DS
+                  for (int j = 0; j < N; j = j + (sizeFactor * 2)) {
+
+                    SmallVector<OpFoldResult> offsets = {
+                        rewriter.getIndexAttr(0),
+                        rewriter.getIndexAttr(0),
+                        rewriter.getIndexAttr(j),
+                    };
+
+                    if ((N - j) <= 8) {
+                      llvm::SmallVector<OpFoldResult> sizes = {
+                          rewriter.getIndexAttr(1), rewriter.getIndexAttr(1),
+                          rewriter.getIndexAttr(8)};
+
+                      auto subview = rewriter.create<memref::SubViewOp>(
+                          kForOp.getLoc(), rhsClone->getResult(0), offsets,
+                          sizes, strides_splat);
+
+                      mlir::VectorType dstType = mlir::VectorType::get(
+                          {sizeFactor / 2}, rewriter.getF32Type());
+
+                      auto evenB = rewriter.create<
+                          mlir::x86vector::CvtPackedEvenIndexedToF32Op>(
+                          kForOp.getLoc(), dstType, subview);
+
+                      auto oddB = rewriter.create<
+                          mlir::x86vector::CvtPackedOddIndexedToF32Op>(
+                          kForOp.getLoc(), dstType, subview);
+
+                      auto shuffle = rewriter.create<vector::ShuffleOp>(
+                          kForOp.getLoc(),
+                          VectorType::get({sizeFactor}, rewriter.getF32Type()),
+                          evenB, oddB,
+                          ArrayRef<int64_t>{0, 4, 1, 5, 2, 6, 3, 7});
+
+                      for (int i = 0; i < M; i++) {
+                        auto fmaOdd = rewriter.create<vector::FMAOp>(
+                            kForOp.getLoc(), matf32[i], shuffle,
+                            iterArgsNewKForOp[(j / sizeFactor) +
+                                              (i * (N / sizeFactor))]);
+                        // k++;
+                        oddFMAs.push_back(fmaOdd);
+                      }
+
+                      continue;
+                    }
+
+                    llvm::SmallVector<OpFoldResult> sizes = {
+                        rewriter.getIndexAttr(1), rewriter.getIndexAttr(1),
+                        rewriter.getIndexAttr(16)};
+                    auto subview = rewriter.create<memref::SubViewOp>(
+                        kForOp.getLoc(), rhsClone->getResult(0), offsets, sizes,
+                        strides_splat);
+
+                    auto evenB = rewriter.create<
+                        mlir::x86vector::CvtPackedEvenIndexedToF32Op>(
+                        kForOp.getLoc(), dstType, subview);
+
+                    for (int i = 0; i < M; i++) {
+                      auto fmaOdd = rewriter.create<vector::FMAOp>(
+                          kForOp.getLoc(), matf32[i], evenB,
+                          iterArgsNewKForOp[(j / sizeFactor) +
+                                            (i * (N / sizeFactor))]);
+                      // k++;
+                      oddFMAs.push_back(fmaOdd);
+                    }
+
+                    auto subview1 = rewriter.create<memref::SubViewOp>(
+                        kForOp.getLoc(), rhsClone->getResult(0), offsets, sizes,
+                        strides_splat);
+
+                    auto oddB = rewriter.create<
+                        mlir::x86vector::CvtPackedOddIndexedToF32Op>(
+                        kForOp.getLoc(), dstType, subview1);
+
+                    // Odd FMAs
+                    for (int i = 0; i < M; i++) {
+                      auto fmaOdd = rewriter.create<vector::FMAOp>(
+                          kForOp.getLoc(), matf32[i], oddB,
+                          iterArgsNewKForOp[((j + sizeFactor) / sizeFactor) +
+                                            (i * (N / sizeFactor))]);
+                      // k++;
+                      oddFMAs.push_back(fmaOdd);
+                    }
+                  }
+
+                  // Re-arrange the stored DPs in order of M -> N
+                  for (int i = 0; i < M; i++) {
+                    for (int j = 0; j < (N / sizeFactor); j++) {
+                      evenFMAs.push_back(oddFMAs[i + (j * M)]);
+                    }
+                  }
+                }
+
                 if (isSplat && bf16dp) {
                   if (mDriven) { // M -> N
                     for (int j = 0; j < N; j = j + 32) {
                       Value indexOp_j = rewriter.create<arith::ConstantIndexOp>(
                           reductionForOp.getLoc(), j);
 
-		      // B Matrix load.
-		      // For case where `B` is one vector<32xbf16>, we do interleaving
-		      // with two vector<16xbf16>
+                      // B Matrix load.
+                      // For case where `B` is one vector<32xbf16>, we do
+                      // interleaving with two vector<16xbf16>
                       if ((N - j) <= 16) {
                         auto valueRow1 =
                             rewriterNewKForOp.create<vector::LoadOp>(
@@ -1406,7 +1531,7 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
                     }
 
                   } else { // N -> M
-	            // Load A matrix
+                           // Load A matrix
                     for (int i = 0; i < M; i++) {
                       Value indexOp_i = rewriter.create<arith::ConstantIndexOp>(
                           reductionForOp.getLoc(), i);
@@ -1420,7 +1545,7 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
                       matf32.push_back(valuef32);
                     }
 
-		    // Load B Matrix
+                    // Load B Matrix
                     for (int j = 0; j < N; j = j + (sizeFactor * 2)) {
                       Value indexOp_j = rewriter.create<arith::ConstantIndexOp>(
                           reductionForOp.getLoc(), j);
@@ -1492,8 +1617,8 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
                         }
                       }
                     }
-		    
-		    // Re-arrange the stored DPs in order of M -> N
+
+                    // Re-arrange the stored DPs in order of M -> N
                     for (int i = 0; i < M; i++) {
                       for (int j = 0; j < (N / sizeFactor); j++) {
                         evenFMAs.push_back(oddFMAs[i + (j * M)]);
@@ -1511,9 +1636,93 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
 
     SmallVector<Value> FMAs = newReductionForOp.getResults();
 
-    // On splat layout, we shuffle the acc and add the C 
+    if (isSplat && srf) {
+      SmallVector<Value> splatFMAs;
+
+      for (int i = 0, k = 0; i < M; i++) {
+        for (int j = 0; j < N; j = j + (sizeFactor * 2)) {
+          Value indexOp = rewriter.create<arith::ConstantIndexOp>(
+              reductionForOp.getLoc(), i);
+          Value indexOp_B1 = rewriter.create<arith::ConstantIndexOp>(
+              reductionForOp.getLoc(), j);
+          Value indexOp_B2 = rewriter.create<arith::ConstantIndexOp>(
+              reductionForOp.getLoc(), j + sizeFactor);
+
+          if ((N - j) <= 8) {
+            Value valueCRow1 = rewriter.create<vector::LoadOp>(
+                reductionForOp.getLoc(),
+                VectorType::get(sizeFactor, outsElementType), subviewOpAcc,
+                ValueRange{indexOp, indexOp_B1});
+
+            if (!outsElementType.isF32()) {
+              valueCRow1 = performBitcast(reductionForOp.getLoc(), rewriter,
+                                          valueCRow1, sizeFactor, vnni,
+                                          elementType, i32Type, i16Type, cst16);
+            }
+
+            Value addOp1 = rewriter.create<arith::AddFOp>(
+                reductionForOp.getLoc(), FMAs[k], valueCRow1);
+            splatFMAs.push_back(addOp1);
+            k++;
+            continue;
+          }
+
+          auto shuffle1 = rewriter.create<vector::ShuffleOp>(
+              kForOp.getLoc(),
+              VectorType::get({sizeFactor}, rewriter.getF32Type()), FMAs[k],
+              FMAs[k + 1], ArrayRef<int64_t>{0, 8, 1, 9, 2, 10, 3, 11});
+
+          auto shuffle2 = rewriter.create<vector::ShuffleOp>(
+              kForOp.getLoc(),
+              VectorType::get({sizeFactor}, rewriter.getF32Type()), FMAs[k],
+              FMAs[k + 1], ArrayRef<int64_t>{4, 12, 5, 13, 6, 14, 7, 15});
+
+          Value valueCRow1 = rewriter.create<vector::LoadOp>(
+              reductionForOp.getLoc(),
+              VectorType::get(sizeFactor, outsElementType), subviewOpAcc,
+              ValueRange{indexOp, indexOp_B1});
+
+          if (!outsElementType.isF32()) {
+            valueCRow1 = performBitcast(reductionForOp.getLoc(), rewriter,
+                                        valueCRow1, sizeFactor, vnni,
+                                        elementType, i32Type, i16Type, cst16);
+          }
+
+          Value addOp1 = rewriter.create<arith::AddFOp>(reductionForOp.getLoc(),
+                                                        shuffle1, valueCRow1);
+          splatFMAs.push_back(addOp1);
+
+          Value valueCRow2 = rewriter.create<vector::LoadOp>(
+              reductionForOp.getLoc(),
+              VectorType::get(sizeFactor, outsElementType), subviewOpAcc,
+              ValueRange{indexOp, indexOp_B2});
+
+          if (!outsElementType.isF32()) {
+            valueCRow2 = performBitcast(reductionForOp.getLoc(), rewriter,
+                                        valueCRow2, sizeFactor, vnni,
+                                        elementType, i32Type, i16Type, cst16);
+          }
+
+          Value addOp2 = rewriter.create<arith::AddFOp>(reductionForOp.getLoc(),
+                                                        shuffle2, valueCRow2);
+          splatFMAs.push_back(addOp2);
+
+          k = k + 2;
+        }
+      }
+
+      FMAs.clear();
+      // Re-arrange the stored FMAs in order of M -> N.
+      for (int j = 0; j < (N / sizeFactor); j++) {
+        for (int i = 0; i < M; i++) {
+          FMAs.push_back(splatFMAs[j + (i * (N / sizeFactor))]);
+        }
+      }
+    }
+
+    // On splat layout, we shuffle the acc and add the C
     // matriX value.
-    if (isSplat) {
+    if (isSplat && bf16dp) {
       SmallVector<Value> splatFMAs;
 
       for (int i = 0, k = 0; i < M; i++) {
@@ -1544,14 +1753,16 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
 
           } else { // Case: two vector<32xbf16>
             auto shuffle1 = rewriter.create<vector::ShuffleOp>(
-                kForOp.getLoc(), VectorType::get({sizeFactor}, rewriter.getF32Type()),
-                FMAs[k], FMAs[k + 1],
+                kForOp.getLoc(),
+                VectorType::get({sizeFactor}, rewriter.getF32Type()), FMAs[k],
+                FMAs[k + 1],
                 ArrayRef<int64_t>{0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20,
                                   21, 22, 23});
 
             auto shuffle2 = rewriter.create<vector::ShuffleOp>(
-                kForOp.getLoc(), VectorType::get({sizeFactor}, rewriter.getF32Type()),
-                FMAs[k], FMAs[k + 1],
+                kForOp.getLoc(),
+                VectorType::get({sizeFactor}, rewriter.getF32Type()), FMAs[k],
+                FMAs[k + 1],
                 ArrayRef<int64_t>{8, 9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15,
                                   28, 29, 30, 31});
 

--- a/test/BF16/Integration/ARL/lit.local.cfg
+++ b/test/BF16/Integration/ARL/lit.local.cfg
@@ -1,0 +1,45 @@
+import subprocess
+
+def has_support(feature):
+    # uArch detection not working on Windows
+    if sys.platform in ['win32']:
+        return False
+
+    try:
+        cmd = subprocess.Popen(
+            ['grep', feature, '/proc/cpuinfo'], stdout=subprocess.PIPE)
+    except OSError:
+        return False
+
+    out = cmd.stdout.read().decode('ascii')
+    cmd.wait()
+
+    if out == "":
+        return False
+
+    return True
+
+def is_arch(target):
+    # Arch detection not working on Windows
+    if sys.platform in ['win32']:
+        return False
+
+    try:
+        cmd = subprocess.Popen(
+            ['uname', '-m'], stdout=subprocess.PIPE)
+    except OSError:
+        return False
+
+    out = cmd.stdout.read().decode('ascii')
+    cmd.wait()
+
+    return target in out
+
+
+# Enable only on x86
+if not is_arch('x86'):
+    config.unsupported = True
+
+# AVX2
+if not has_support('avx2'):
+    config.unsupported = True

--- a/test/BF16/Integration/ARL/lit.local.cfg
+++ b/test/BF16/Integration/ARL/lit.local.cfg
@@ -43,3 +43,7 @@ if not is_arch('x86'):
 # AVX2
 if not has_support('avx2'):
     config.unsupported = True
+
+# This test not to run on AVX-512
+if has_support('avx512'):
+    config.unsupported = True

--- a/test/BF16/Integration/ARL/vector-contract-to-fma-avx2.mlir
+++ b/test/BF16/Integration/ARL/vector-contract-to-fma-avx2.mlir
@@ -1,0 +1,46 @@
+// RUN: tpp-run -e gemm_splat --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
+// RUN: tpp-run -e gemm_splat --entry-point-result=void -print --disable-vnni-packing --vector-to-kernels --registerBlocking=4,16,1  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
+// RUN: fpcmp -r 0.01 %t.1 %t.2
+
+func.func @gemm_splat(%arg0: tensor<8x32x32x32xbf16>, %arg1: tensor<32x32x32x32xbf16>, %arg2: tensor<8x32x32x32xbf16>) -> tensor<8x32x32x32xbf16> {
+  %0 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<8x32x32x32xbf16>, tensor<32x32x32x32xbf16>) outs(%arg2 : tensor<8x32x32x32xbf16>) {
+  ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+    %1 = arith.mulf %in, %in_0 : bf16
+    %2 = arith.addf %out, %1 : bf16
+    linalg.yield %2 : bf16
+  } -> tensor<8x32x32x32xbf16>
+  return %0 : tensor<8x32x32x32xbf16>
+}
+
+// -----
+
+// RUN: tpp-run -e mlp_splat --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
+// RUN: tpp-run -e mlp_splat --entry-point-result=void -print --disable-vnni-packing --vector-to-kernels --registerBlocking=4,16,1  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
+// RUN: fpcmp -r 0.01 %t.1 %t.2
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+func.func @mlp_splat(%arg0: tensor<8x32x32x32xbf16>, %arg1: tensor<32x32x32x32xbf16>, %arg2: tensor<32x32xbf16>, %arg3: tensor<8x32x32x32xbf16>) -> tensor<8x32x32x32xbf16> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<8x32x32x32xbf16>, tensor<32x32x32x32xbf16>) outs(%arg3 : tensor<8x32x32x32xbf16>) {
+  ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+    %3 = arith.mulf %in, %in_0 : bf16
+    %4 = arith.addf %out, %3 : bf16
+    linalg.yield %4 : bf16
+  } -> tensor<8x32x32x32xbf16>
+  %1 = linalg.generic {indexing_maps = [#map3, #map4], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg2 : tensor<32x32xbf16>) outs(%0 : tensor<8x32x32x32xbf16>) {
+  ^bb0(%in: bf16, %out: bf16):
+    %3 = arith.addf %in, %out : bf16
+    linalg.yield %3 : bf16
+  } -> tensor<8x32x32x32xbf16>
+  %cst = arith.constant 0.000000e+00 : bf16
+  %2 = linalg.generic {indexing_maps = [#map4], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} outs(%1 : tensor<8x32x32x32xbf16>) {
+  ^bb0(%out: bf16):
+    %3 = arith.maximumf %out, %cst : bf16
+    linalg.yield %3 : bf16
+  } -> tensor<8x32x32x32xbf16>
+  return %2 : tensor<8x32x32x32xbf16>
+}
+

--- a/test/Passes/uKernels/avx2-splat/lit.local.cfg
+++ b/test/Passes/uKernels/avx2-splat/lit.local.cfg
@@ -1,0 +1,49 @@
+import subprocess
+
+def has_support(feature):
+    # uArch detection not working on Windows
+    if sys.platform in ['win32']:
+        return False
+
+    try:
+        cmd = subprocess.Popen(
+            ['grep', feature, '/proc/cpuinfo'], stdout=subprocess.PIPE)
+    except OSError:
+        return False
+
+    out = cmd.stdout.read().decode('ascii')
+    cmd.wait()
+
+    if out == "":
+        return False
+
+    return True
+
+def is_arch(target):
+    # Arch detection not working on Windows
+    if sys.platform in ['win32']:
+        return False
+
+    try:
+        cmd = subprocess.Popen(
+            ['uname', '-m'], stdout=subprocess.PIPE)
+    except OSError:
+        return False
+
+    out = cmd.stdout.read().decode('ascii')
+    cmd.wait()
+
+    return target in out
+
+
+# Enable only on x86
+if not is_arch('x86'):
+    config.unsupported = True
+
+# AVX2
+if not has_support('avx2'):
+    config.unsupported = True
+
+# This test is targeted only for AVX2
+if has_support('avx512'):
+    config.unsupported = True

--- a/test/Passes/uKernels/avx2-splat/pass-vector-contract-to-FMAs.mlir
+++ b/test/Passes/uKernels/avx2-splat/pass-vector-contract-to-FMAs.mlir
@@ -1,0 +1,45 @@
+// RUN: tpp-opt %s --vector-contract-to-micro-kernels="target-feature=avx2"  --split-input-file  | FileCheck -check-prefix=CHECK %s
+
+module {
+  func.func @gemm_splat(%arg0: memref<1x3x32xbf16>, %arg1: memref<1x32x32xbf16>, %arg2: memref<3x32xbf16>) -> memref<3x32xbf16> {
+    %0 = ub.poison : bf16
+    %c0 = arith.constant 0 : index
+    %c3 = arith.constant 3 : index
+    %c32 = arith.constant 32 : index
+    %c1 = arith.constant 1 : index
+    scf.for %arg3 = %c0 to %c3 step %c3 {
+      scf.for %arg4 = %c0 to %c32 step %c32 {
+        %subview = memref.subview %arg2[%arg3, %arg4] [3, 32] [1, 1] : memref<3x32xbf16> to memref<3x32xbf16, strided<[32, 1], offset: ?>>
+        %1 = vector.transfer_read %subview[%c0, %c0], %0 {in_bounds = [true, true]} : memref<3x32xbf16, strided<[32, 1], offset: ?>>, vector<3x32xbf16>
+        %2 = scf.for %arg5 = %c0 to %c1 step %c1 iter_args(%arg6 = %1) -> (vector<3x32xbf16>) {
+          %3 = scf.for %arg7 = %c0 to %c32 step %c1 iter_args(%arg8 = %arg6) -> (vector<3x32xbf16>) {
+            %subview_0 = memref.subview %arg0[%arg5, %arg3, %arg7] [1, 3, 1] [1, 1, 1] : memref<1x3x32xbf16> to memref<1x3x1xbf16, strided<[96, 32, 1], offset: ?>>
+            %subview_1 = memref.subview %arg1[%arg5, %arg7, %arg4] [1, 1, 32] [1, 1, 1] : memref<1x32x32xbf16> to memref<1x1x32xbf16, strided<[1024, 32, 1], offset: ?>>
+            %4 = vector.transfer_read %subview_0[%c0, %c0, %c0], %0 {in_bounds = [true, true, true]} : memref<1x3x1xbf16, strided<[96, 32, 1], offset: ?>>, vector<1x3x1xbf16>
+            %5 = vector.transfer_read %subview_1[%c0, %c0, %c0], %0 {in_bounds = [true, true, true]} : memref<1x1x32xbf16, strided<[1024, 32, 1], offset: ?>>, vector<1x1x32xbf16>
+            %6 = vector.contract {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>, affine_map<(d0, d1, d2, d3) -> (d1, d2)>], iterator_types = ["reduction", "parallel", "parallel", "reduction"], kind = #vector.kind<add>} %4, %5, %arg8 : vector<1x3x1xbf16>, vector<1x1x32xbf16> into vector<3x32xbf16>
+            scf.yield %6 : vector<3x32xbf16>
+          }
+          scf.yield %3 : vector<3x32xbf16>
+        }
+        vector.transfer_write %2, %subview[%c0, %c0] {in_bounds = [true, true]} : vector<3x32xbf16>, memref<3x32xbf16, strided<[32, 1], offset: ?>>
+      }
+    }
+    return %arg2 : memref<3x32xbf16>
+  }
+}
+
+// CHECK-LABEL:   func.func @gemm_splat
+// We leverage the ARL nature and do even->odd loads
+// CHECK: x86vector.avx.cvt.packed.even.indexed_to_f32
+// CHECK-NEXT: vector.fma{{.*}}vector<8xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<8xf32>
+// CHECK-NEXT: vector.fma{{.*}}vector<8xf32>
+// CHECK: x86vector.avx.cvt.packed.odd.indexed_to_f32
+// CHECK: x86vector.avx.cvt.packed.even.indexed_to_f32
+// CHECK: x86vector.avx.cvt.packed.odd.indexed_to_f32
+// The final accumulated value has to be shuffled as the load is even+odd
+// CHECK: vector.shuffle{{.*}}[0, 8, 1, 9, 2, 10, 3, 11] : vector<8xf32>, vector<8xf32>
+// CHECK: vector.shuffle{{.*}}[4, 12, 5, 13, 6, 14, 7, 15] : vector<8xf32>, vector<8xf32>
+
+// -----


### PR DESCRIPTION
This `patch` supports micro-kernel lowering for `bf16` splat layouts on `ARL` kind of machines.

`TODO`: Once all the lowering for `bf16 splat` layout on different machines completed. We will factor them under one `if` branch.