### PR TITLE
[μKernels]: Fix the broken ARM FP32 micro-kernel lowering

### DIFF
--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -117,21 +117,21 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=8,32,1'" ],
+      "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=8,32,1'" ],
       "extensions": ["avx512.*"]
     },
     "mlp_fp32_mlir_vector_avx2": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
+      "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": ["avx2" ]
     },
     "mlp_fp32_mlir_vector_sve": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=4,32,1 -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
+      "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=4,32,1 -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": ["asimd"]
     },
     "mlp_bf16_vnni_dp2_mlir": {
@@ -145,14 +145,14 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "avx512.*" ]
     },
     "mlp_bf16_vnni_dp2_mlir_vector_kernel_avx2": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "avx2" ]
     },
     "mlp_bf16_splat_dp2_mlir": {
@@ -270,7 +270,7 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,1'" ],
+      "flags": [ "-n", "100", "-run-args='--def-parallel  --vector-to-kernels --registerBlocking=8,32,1'" ],
       "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_args_mlir": {
@@ -284,7 +284,7 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,1'" ],
+      "flags": [ "-n", "100", "-run-args=' --def-parallel  --vector-to-kernels --registerBlocking=8,32,1'" ],
       "extensions": [ "avx512.*" ]
     },
     "bf16_3x1024_const_mlir": {

--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -117,21 +117,21 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args=' --vector-to-kernels --registerBlocking=8,32,1'" ],
+      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=8,32,1'" ],
       "extensions": ["avx512.*"]
     },
     "mlp_fp32_mlir_vector_avx2": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args=' --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
+      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": ["avx2" ]
     },
     "mlp_fp32_mlir_vector_sve": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args=' --vector-to-kernels --registerBlocking=4,32,1 -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
+      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=4,32,1 -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": ["asimd"]
     },
     "mlp_bf16_vnni_dp2_mlir": {
@@ -145,14 +145,14 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args=' --vector-to-kernels --registerBlocking=8,32,2'" ],
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "avx512.*" ]
     },
     "mlp_bf16_vnni_dp2_mlir_vector_kernel_avx2": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args=' --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "avx2" ]
     },
     "mlp_bf16_splat_dp2_mlir": {

--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -52,9 +52,9 @@
     },
     "gemm_fp32_mlir_vector_sve": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=4,32,1'" ],
+      "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=4,32,1 -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": ["asimd"]
     },
     "gemm_bf16_vnni_dp2_mlir": {
@@ -117,21 +117,21 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=8,32,1'" ],
+      "flags": [ "-n", "100",  "-run-args=' --vector-to-kernels --registerBlocking=8,32,1'" ],
       "extensions": ["avx512.*"]
     },
     "mlp_fp32_mlir_vector_avx2": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
+      "flags": [ "-n", "100",  "-run-args=' --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": ["avx2" ]
     },
     "mlp_fp32_mlir_vector_sve": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=4,32,1'" ],
+      "flags": [ "-n", "100",  "-run-args=' --vector-to-kernels --registerBlocking=4,32,1 -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": ["asimd"]
     },
     "mlp_bf16_vnni_dp2_mlir": {
@@ -145,14 +145,14 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --registerBlocking=8,32,2'" ],
+      "flags": [ "-n", "100", "-run-args=' --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "avx512.*" ]
     },
     "mlp_bf16_vnni_dp2_mlir_vector_kernel_avx2": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
+      "flags": [ "-n", "100", "-run-args=' --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "avx2" ]
     },
     "mlp_bf16_splat_dp2_mlir": {
@@ -270,7 +270,7 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args='--def-parallel  --vector-to-kernels --registerBlocking=8,32,1'" ],
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,1'" ],
       "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_args_mlir": {
@@ -284,7 +284,7 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024" ],
       "environment": {},
-      "flags": [ "-n", "100", "-run-args=' --def-parallel  --vector-to-kernels --registerBlocking=8,32,1'" ],
+      "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,1'" ],
       "extensions": [ "avx512.*" ]
     },
     "bf16_3x1024_const_mlir": {

--- a/benchmarks/config/omp/mlir-fp32-vector-to-kernel.json
+++ b/benchmarks/config/omp/mlir-fp32-vector-to-kernel.json
@@ -189,28 +189,28 @@
   "gemm_fp32_mlir_vector_kernel_32_sve": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=4,32,1   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=4,32,1   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,32,1   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=4,32,1   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": [ "asimd" ]
@@ -220,28 +220,28 @@
   "mlp_fp32_mlir_vector_kernel_32_sve": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=4,32,1   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=4,32,1   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,32,1   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=4,32,1   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": [ "asimd" ]

--- a/include/TPP/Transforms/Utils/VNNIUtils.h
+++ b/include/TPP/Transforms/Utils/VNNIUtils.h
@@ -36,14 +36,18 @@ enum class VnniOperandRank {
   BRGEMM_INS = 4,
   BRGEMM_OUTS = 3
 };
-// Returns True if the current architecture supports AVX2 instructions.
+
+// Returns true if the current architecture supports AVX2 instructions.
 bool hasAVX2();
 
-// Returns True if the current architecture supports AVX512 instructions.
+// Returns true if the current architecture supports AVX512 instructions.
 bool hasAVX512();
 
-// Returns True if the current architecture supports AMX instructions.
+// Returns true if the current architecture supports AMX instructions.
 bool hasAMX();
+
+// Returns true if the current architecture is not x86.
+bool isNotX86();
 
 // Returns the current target architecture name
 std::string getTargetArchName();

--- a/include/TPP/Transforms/Utils/VNNIUtils.h
+++ b/include/TPP/Transforms/Utils/VNNIUtils.h
@@ -46,8 +46,11 @@ bool hasAVX512();
 // Returns true if the current architecture supports AMX instructions.
 bool hasAMX();
 
-// Returns true if the current architecture is not x86.
-bool isNotX86();
+// Returns true if the current architecture supports SVE-256 instructions.
+bool hasSVE256();
+
+// Returns true if the current architecture supports SVE-512 instructions.
+bool hasSVE512();
 
 // Returns the current target architecture name
 std::string getTargetArchName();

--- a/lib/TPP/Transforms/Utils/VNNIUtils.cpp
+++ b/lib/TPP/Transforms/Utils/VNNIUtils.cpp
@@ -23,22 +23,28 @@ namespace mlir {
 namespace vnni {
 namespace utils {
 
-// Returns True if the current architecture supports AMX instructions.
+// Returns true if the current architecture supports AMX instructions.
 bool hasAMX() {
   return (libxsmm_get_target_archid() >= LIBXSMM_X86_AVX512_SPR) &&
          (libxsmm_get_target_archid() < LIBXSMM_X86_ALLFEAT);
 }
 
-// Returns True if the current architecture supports AMX instructions.
+// Returns true if the current architecture supports AVX2 instructions.
 bool hasAVX2() {
   return (libxsmm_get_target_archid() >= LIBXSMM_X86_AVX2) &&
          (libxsmm_get_target_archid() < LIBXSMM_X86_ALLFEAT);
 }
 
-// Returns True if the current architecture supports AMX instructions.
+// Returns True if the current architecture supports AVX512 instructions.
 bool hasAVX512() {
   return (libxsmm_get_target_archid() >= LIBXSMM_X86_AVX512_SKX) &&
          (libxsmm_get_target_archid() < LIBXSMM_X86_ALLFEAT);
+}
+
+// Returns true if the current architecture is not x86.
+bool isNotX86() {
+  return (libxsmm_get_target_archid() >= LIBXSMM_AARCH64_V81) &&
+         (libxsmm_get_target_archid() <= LIBXSMM_RV64_ALLFEAT);
 }
 
 // Returns the current target architecture name

--- a/lib/TPP/Transforms/Utils/VNNIUtils.cpp
+++ b/lib/TPP/Transforms/Utils/VNNIUtils.cpp
@@ -41,10 +41,16 @@ bool hasAVX512() {
          (libxsmm_get_target_archid() < LIBXSMM_X86_ALLFEAT);
 }
 
-// Returns true if the current architecture is not x86.
-bool isNotX86() {
-  return (libxsmm_get_target_archid() >= LIBXSMM_AARCH64_V81) &&
-         (libxsmm_get_target_archid() <= LIBXSMM_RV64_ALLFEAT);
+// Returns true if the current architecture supports SVE-256 instructions.
+bool hasSVE256() {
+  return (libxsmm_get_target_archid() >= LIBXSMM_AARCH64_NEOV2) &&
+         (libxsmm_get_target_archid() <= LIBXSMM_AARCH64_NEOV1);
+}
+
+// Returns true if the current architecture supports SVE-512 instructions.
+bool hasSVE512() {
+  return (libxsmm_get_target_archid() >= LIBXSMM_AARCH64_SVE512) &&
+         (libxsmm_get_target_archid() <= LIBXSMM_AARCH64_A64FX);
 }
 
 // Returns the current target architecture name

--- a/lib/TPP/Transforms/VectorContractToMicroKernels.cpp
+++ b/lib/TPP/Transforms/VectorContractToMicroKernels.cpp
@@ -347,12 +347,14 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
     // We get target architecture and decide on uKernel lowering using flags
     bool avx512 = vnni::utils::hasAVX512();
     bool avx2 = vnni::utils::hasAVX2();
+    bool sve256 = vnni::utils::hasSVE256();
+    bool sve512 = vnni::utils::hasSVE512();
 
     // disable avx512, if target feature is avx2
     if (options.targetFeature == "avx2")
       avx512 = false;
 
-    int64_t sizeFactor = avx512 ? 16 : avx2 ? 8 : 0;
+    int64_t sizeFactor = (avx512 || sve512) ? 16 : (avx2 || sve256) ? 8 : 0;
 
     bool isF32 = elementType.isF32();
     bool isF16 = elementType.isF16();
@@ -361,19 +363,15 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
 
     bool isPackedType = isF16 || isBF16 || isI8;
 
-    if (vnni::utils::isNotX86()) {
-      sizeFactor = 8;
-
-      if (isPackedType)
-        return rewriter.notifyMatchFailure(
-            contractOp,
-            "only FP32 type lowering is supported for non x86 machines.");
-    }
-
     if (sizeFactor == 0)
       return rewriter.notifyMatchFailure(
-          contractOp, "AVX512 or AVX2 instruction set is not available or "
+          contractOp, "AVX512 or AVX2 or SVE512/256 instruction set is not available or "
                       "lowering is not available for this target machine.");
+
+    if ((sve256 || sve512) && isPackedType)
+      return rewriter.notifyMatchFailure(
+            contractOp,
+            "only FP32 type lowering is supported for AARCH64(ARM) machines.");
 
     int64_t vnniFactor = (isBF16 || isF16) ? 2 : isI8 ? 4 : 1;
     bool isSplat = false;

--- a/lib/TPP/Transforms/VectorContractToMicroKernels.cpp
+++ b/lib/TPP/Transforms/VectorContractToMicroKernels.cpp
@@ -362,16 +362,18 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
     bool isPackedType = isF16 || isBF16 || isI8;
 
     if (vnni::utils::isNotX86()) {
-        sizeFactor = 8;
+      sizeFactor = 8;
 
-	if (isPackedType)
-	  return rewriter.notifyMatchFailure(
-	      contractOp, "only FP32 type lowering is supported for non x86 machines");
+      if (isPackedType)
+        return rewriter.notifyMatchFailure(
+            contractOp,
+            "only FP32 type lowering is supported for non x86 machines");
     }
 
     if (sizeFactor == 0)
       return rewriter.notifyMatchFailure(
-          contractOp, "AVX512 or AVX2 instruction set is not available or lowering is not available for this target machine");
+          contractOp, "AVX512 or AVX2 instruction set is not available or "
+                      "lowering is not available for this target machine");
 
     int64_t vnniFactor = (isBF16 || isF16) ? 2 : isI8 ? 4 : 1;
     bool isSplat = false;

--- a/lib/TPP/Transforms/VectorContractToMicroKernels.cpp
+++ b/lib/TPP/Transforms/VectorContractToMicroKernels.cpp
@@ -367,13 +367,13 @@ struct MicroKernelsOp : OpRewritePattern<vector::ContractionOp> {
       if (isPackedType)
         return rewriter.notifyMatchFailure(
             contractOp,
-            "only FP32 type lowering is supported for non x86 machines");
+            "only FP32 type lowering is supported for non x86 machines.");
     }
 
     if (sizeFactor == 0)
       return rewriter.notifyMatchFailure(
           contractOp, "AVX512 or AVX2 instruction set is not available or "
-                      "lowering is not available for this target machine");
+                      "lowering is not available for this target machine.");
 
     int64_t vnniFactor = (isBF16 || isF16) ? 2 : isI8 ? 4 : 1;
     bool isSplat = false;


### PR DESCRIPTION
This `patch` fixes the Issue: https://github.com/libxsmm/tpp-mlir/issues/1086 broken ARM FP32 micro-kernel lowering.