### PR TITLE
[CI] Update the CUDA salloc

### DIFF
--- a/.github/workflows/tpp-llvm.yml
+++ b/.github/workflows/tpp-llvm.yml
@@ -27,6 +27,6 @@ jobs:
       - name: LLVM CUDA
         run: |-
               GPU=cuda scripts/github/check_llvm.sh || \
-              ${{ env.SRUN }} --partition=a100,v100 --time=0:30:00 -- \
+              ${{ env.SRUN }} --partition=a100 --time=0:30:00 -- \
               'KIND=RelWithDebInfo COMPILER=clang GPU=cuda \
               ${{ github.workspace }}/scripts/github/build_llvm.sh'


### PR DESCRIPTION
With the recent changes in `pcl-tiergarten` the `v100` support is no more available. So, we update the `CI` salloc partition.