### PR TITLE
Feat/streaming store

### DIFF
--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -96,6 +96,18 @@ def FlattenVectorOps : Pass<"flatten-vector-ops"> {
   let dependentDialects = [ "vector::VectorDialect" ];
 }
 
+def ConvertToStreamingStore : Pass<"convert-to-streaming-store"> {
+  let summary = "Convert write-only vector.transfer_write into a nontemporal vector.store.";
+  let description = [{
+    Rewrites a vector.transfer_write into a vector.store carrying the
+    nontemporal = true attribute when the destination buffer is never read
+    back (no immediate or future load from it within the function), e.g. the
+    output C matrix of a GEMM. Streaming such write-only stores avoids
+    polluting the cache with data that is not reused.
+  }];
+  let dependentDialects = [ "vector::VectorDialect" ];
+}
+
 def VectorContractToOuterproduct : Pass<
     "vector-contract-to-outerproduct"> {
   let summary = "Perform outerproduct lowering of vector contraction ops";

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -103,9 +103,16 @@ private:
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     pm.addNestedPass<func::FuncOp>(createLoopInvariantCodeMotionPass());
     pm.addPass(createBufferize());
+    // Replicate benchmark kernel arguments for cold-cache timing. Runs on
+    // bufferized memrefs so replicas are plain subviews (no allocs/copies).
+    // No-op unless the benchmark producer requested replication.
+    pm.addPass(createReplicateBenchArgs());
     pm.addNestedPass<func::FuncOp>(createVectorContractToNanoKernels());
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     pm.addNestedPass<func::FuncOp>(createFlattenVectorOps());
+    // Stream write-only stores (e.g. the output C matrix) with a nontemporal
+    // hint. Runs after flattening so the transfer_write is already 1-D.
+    pm.addNestedPass<func::FuncOp>(createConvertToStreamingStore());
   }
 
   // Default TPP lowering: map and pack at the linalg level, bufferize, lower to
@@ -135,13 +142,13 @@ private:
       pm.addPass(createSCFForAllLoopFlattenSFC());
 
     // Bufferize: tensor->memref.
-    if (!nanoKernel)
+    if (!nanoKernel) {
       pm.addPass(createBufferize());
-
-    // Replicate benchmark kernel arguments for cold-cache timing. Runs on
-    // bufferized memrefs so replicas are plain subviews (no allocs/copies).
-    // No-op unless the benchmark producer requested replication.
-    pm.addPass(createReplicateBenchArgs());
+      // Replicate benchmark kernel arguments for cold-cache timing. Runs on
+      // bufferized memrefs so replicas are plain subviews (no allocs/copies).
+      // No-op unless the benchmark producer requested replication.
+      pm.addPass(createReplicateBenchArgs());
+    }
 
     if (nanoKernel)
       // Lower Linalg to Vector.

--- a/lib/TPP/Runner/MLIRBench.cpp
+++ b/lib/TPP/Runner/MLIRBench.cpp
@@ -269,9 +269,12 @@ LogicalResult MLIRBench::createKernelArgs() {
       argInitType = TensorInitType::Normal;
     }
 
-    // Scale arguments are paired with corresponding input and weight matrices.
+    // Scale arguments are marked by the generator with the `tpp.quant_scale`
+    // argument attribute (used for input/weight dequant scales and the requant
+    // output scale).
     bool isScaleArgument =
-        argInitType == TensorInitType::Quant && (argNum == 1 || argNum == 3);
+        argInitType == TensorInitType::Quant &&
+        kernel.getArgAttr(argNum, "tpp.quant_scale") != nullptr;
     auto arg =
         TypeSwitch<Type, std::optional<Value>>(argTy)
             .Case<MemRefType>([&](auto memRefTy) {

--- a/lib/TPP/Transforms/CMakeLists.txt
+++ b/lib/TPP/Transforms/CMakeLists.txt
@@ -36,6 +36,7 @@ add_mlir_library(TPPTransforms
   HoistLoopInvariantSubsets.cpp
   VectorContractToNanoKernels.cpp
   FlattenVectorOps.cpp
+  ConvertToStreamingStore.cpp
   TileDequantElementwiseOps.cpp
   ConvertLinalgGenericTo32BitAccumulation.cpp
 

--- a/lib/TPP/Transforms/ConvertToStreamingStore.cpp
+++ b/lib/TPP/Transforms/ConvertToStreamingStore.cpp
@@ -1,0 +1,128 @@
+//===- ConvertToStreamingStore.cpp -------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Passes.h"
+
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+using namespace mlir;
+
+namespace mlir {
+namespace tpp {
+#define GEN_PASS_DEF_CONVERTTOSTREAMINGSTORE
+#include "TPP/Passes.h.inc"
+} // namespace tpp
+} // namespace mlir
+
+namespace {
+
+// Walk view-like ops back to the underlying root buffer that the given memref
+// value aliases.
+static Value getRootMemref(Value memref) {
+  while (auto view = memref.getDefiningOp<ViewLikeOpInterface>())
+    memref = view.getViewSource();
+  return memref;
+}
+
+// Returns true if the root buffer, and every memref value that aliases it
+// through view-like ops, is never read. Conservatively returns false whenever
+// a user cannot be proven read-free (unknown memory effects, escaping uses).
+static bool isWriteOnly(Value root) {
+  SmallVector<Value> worklist{root};
+  SmallPtrSet<Value, 8> visited;
+  while (!worklist.empty()) {
+    Value cur = worklist.pop_back_val();
+    if (!visited.insert(cur).second)
+      continue;
+    for (Operation *user : cur.getUsers()) {
+      // A view-like user only creates a new alias; keep tracing it.
+      if (isa<ViewLikeOpInterface>(user)) {
+        for (Value res : user->getResults())
+          if (isa<MemRefType>(res.getType()))
+            worklist.push_back(res);
+        continue;
+      }
+      // Any user with unknown effects might read the buffer.
+      auto memEffects = dyn_cast<MemoryEffectOpInterface>(user);
+      if (!memEffects)
+        return false;
+      SmallVector<MemoryEffects::EffectInstance> effects;
+      memEffects.getEffects(effects);
+      for (const MemoryEffects::EffectInstance &effect : effects) {
+        if (!isa<MemoryEffects::Read>(effect.getEffect()))
+          continue;
+        // A read we cannot pin to another value might touch this buffer.
+        Value effectValue = effect.getValue();
+        if (!effectValue || effectValue == cur)
+          return false;
+      }
+    }
+  }
+  return true;
+}
+
+// Rewrites a vector.transfer_write whose destination buffer is never read back
+// into a vector.store with the nontemporal = true attribute.
+struct TransferWriteToStreamingStore
+    : OpRewritePattern<vector::TransferWriteOp> {
+  using OpRewritePattern<vector::TransferWriteOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::TransferWriteOp writeOp,
+                                PatternRewriter &rewriter) const override {
+    // A plain vector.store can only replace a write into a memref.
+    if (!isa<MemRefType>(writeOp.getShapedType()))
+      return rewriter.notifyMatchFailure(writeOp,
+                                         "expects a memref destination");
+
+    // Masked or non-contiguous transfers cannot be lowered to a plain store.
+    if (writeOp.getMask())
+      return rewriter.notifyMatchFailure(writeOp, "masked transfer write");
+    if (!writeOp.getPermutationMap().isMinorIdentity())
+      return rewriter.notifyMatchFailure(writeOp,
+                                         "non minor-identity permutation map");
+    if (!llvm::all_of(writeOp.getInBoundsValues(),
+                      [](bool inBounds) { return inBounds; }))
+      return rewriter.notifyMatchFailure(writeOp,
+                                         "out-of-bounds transfer write");
+
+    // Only rank-1 vector.store ops lower to LLVM; expect the transfers to have
+    // already been flattened.
+    if (writeOp.getVectorType().getRank() != 1)
+      return rewriter.notifyMatchFailure(writeOp, "expects a 1-D vector write");
+
+    // Only stream stores whose destination buffer is never read back.
+    if (!isWriteOnly(getRootMemref(writeOp.getBase())))
+      return rewriter.notifyMatchFailure(
+          writeOp, "destination buffer is read; not a streaming store");
+
+    rewriter.replaceOpWithNewOp<vector::StoreOp>(
+        writeOp, writeOp.getVector(), writeOp.getBase(), writeOp.getIndices(),
+        /*nontemporal=*/true);
+    return success();
+  }
+};
+
+struct ConvertToStreamingStore
+    : public tpp::impl::ConvertToStreamingStoreBase<ConvertToStreamingStore> {
+  using ConvertToStreamingStoreBase::ConvertToStreamingStoreBase;
+
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<TransferWriteToStreamingStore>(&getContext());
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+      return signalPassFailure();
+  }
+};
+
+} // namespace

--- a/lib/TPP/Transforms/Utils/TensorInit.cpp
+++ b/lib/TPP/Transforms/Utils/TensorInit.cpp
@@ -113,6 +113,15 @@ TensorInitPtr getTensorInit(TensorInitType type, mlir::Type elmType,
     case TensorInitType::Identity:
       initPtr = std::make_shared<IdentityTensorInitFloat>(dataType);
       break;
+    case TensorInitType::Quant:
+      // A floating-point Quant argument is only valid as a self-generating
+      // scale initializer (e.g. the requantization output scale); quantized
+      // data matrices are handled by the integer branch above.
+      assert(seed && "Can't call random initializers without seed");
+      assert(isScaleArgument &&
+             "Floating-point Quant init is only supported for scale arguments");
+      initPtr = std::make_shared<QuantScaleTensorInitFloat>(dataType, seed);
+      break;
     default:
       assert(false && "Invalid tensor initializer type");
     }
@@ -144,16 +153,26 @@ TensorInitPtr getTensorInit(TensorInitType type, mlir::Type elmType,
       // the initialization for the quantized argument and corresponding
       // dequant scale factors.
       assert(seed && "Can't call random initializers without seed");
-      auto floatScaleDataType =
-          TensorInitFloat::getTensorInitDataType(nextElmType);
-      TensorInitPtr floatScaleInit =
-          std::make_shared<QuantScaleTensorInitFloat>(floatScaleDataType, seed);
+      // A paired float scale is only produced when the quantized data matrix is
+      // immediately followed by a floating-point scale argument (dequant). For
+      // requantization the i8 inputs are not followed by a float scale here, so
+      // skip pairing to avoid constructing an invalid (integer) scale type.
+      bool hasFloatScale = nextElmType && nextElmType.isFloat();
+      TensorInitPtr floatScaleInit = nullptr;
+      if (hasFloatScale) {
+        auto floatScaleDataType =
+            TensorInitFloat::getTensorInitDataType(nextElmType);
+        floatScaleInit = std::make_shared<QuantScaleTensorInitFloat>(
+            floatScaleDataType, seed);
+      }
       if (!isScaleArgument) {
         initPtr = std::make_shared<QuantTensorInitInt>(dataType, nextElmType,
                                                        seed, floatScaleInit);
         // Store the float/int initializer for dequant scale factors into hash.
-        InitKey keyFloatScale(type, nextElmType, seed, true);
-        tensorInitializers[keyFloatScale] = floatScaleInit;
+        if (hasFloatScale) {
+          InitKey keyFloatScale(type, nextElmType, seed, true);
+          tensorInitializers[keyFloatScale] = floatScaleInit;
+        }
       }
       break;
     }

--- a/lib/TPP/Transforms/Utils/TensorInitFloat.cpp
+++ b/lib/TPP/Transforms/Utils/TensorInitFloat.cpp
@@ -109,8 +109,20 @@ void IdentityTensorInitFloat::fillData() {
 
 // Update internal buffer with rescale values.
 void QuantScaleTensorInitFloat::fillData() {
-  assert(scaleBuffer.size() > 0 && "scaleBuffer is empty");
-  for (size_t i = 0; i < scaleBuffer.size(); i++) {
-    push(scaleBuffer[i]);
+  // When paired with a quantized data matrix (dequantization), the scale buffer
+  // is populated externally. Otherwise (e.g. the requantization output scale)
+  // self-generate random positive per-channel scale factors.
+  if (!scaleBuffer.empty()) {
+    for (size_t i = 0; i < scaleBuffer.size(); i++) {
+      push(scaleBuffer[i]);
+    }
+    return;
+  }
+  for (size_t i = 0; i < size; i++) {
+    float value = distribution(generator);
+    if (value < 0.0f)
+      value = -value;
+    // Keep scales strictly positive and away from zero.
+    push(value + 1e-3f);
   }
 }

--- a/test/Integration/I8/AMX/tpp-run-gemm-dequantize-correctness-i8-f32-diffscale.mlir
+++ b/test/Integration/I8/AMX/tpp-run-gemm-dequantize-correctness-i8-f32-diffscale.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run -e entry --entry-point-result=void --linalg-to-loops -print --splat-to-random --init-type quant -seed 123  %s > %t.1
+// RUN: tpp-run -e entry --entry-point-result=void -print --splat-to-random --init-type quant -seed 123  %s > %t.1
 // RUN: tpp-run -e entry --entry-point-result=void -print --nano-kernels --gemm-unroll=16,16,16 --registerBlocking=32,32,64 --splat-to-random -seed 123 --init-type quant %s > %t.2
 // RUN: fpcmp -r 0.001 %t.1 %t.2
 
@@ -24,9 +24,9 @@
 
 func.func @entry(
     %arg0: tensor<2x2x64x64xi8>,
-    %arg1: tensor<128xf32>,
+    %arg1: tensor<128xf32> {tpp.quant_scale},
     %arg2: tensor<4x2x16x64x4xi8>,
-    %arg3: tensor<256xf32>,
+    %arg3: tensor<256xf32> {tpp.quant_scale},
     %arg4: tensor<2x4x64x64xf32>) -> tensor<2x4x64x64xf32> {
 
   %c0_i32 = arith.constant 0 : i32

--- a/test/Integration/I8/AMX/tpp-run-gemm-dequantize-correctness-i8-f32-i8-scale.mlir
+++ b/test/Integration/I8/AMX/tpp-run-gemm-dequantize-correctness-i8-f32-i8-scale.mlir
@@ -16,7 +16,7 @@
 // IR:   vector.transfer_read
 // IR:   arith.sitofp
 // IR:   arith.mulf
-// IR:   vector.transfer_write
+// IR:   vector.store {{.*}}nontemporal = true
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6, d3)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6, d5, d3)>

--- a/test/Integration/I8/AMX/tpp-run-gemm-dequantize-correctness-i8-f32-i8-scale.mlir
+++ b/test/Integration/I8/AMX/tpp-run-gemm-dequantize-correctness-i8-f32-i8-scale.mlir
@@ -1,6 +1,6 @@
 // RUN: tpp-opt --default-tpp-passes="nano-kernel registerBlocking=32,32,64 gemm-unroll=16,16,16" %s | FileCheck %s -check-prefix=IR
 
-// RUN: tpp-run -e entry --entry-point-result=void --linalg-to-loops -print --splat-to-random --init-type quant -seed 123  %s > %t.1
+// RUN: tpp-run -e entry --entry-point-result=void -print --splat-to-random --init-type quant -seed 123  %s > %t.1
 // RUN: tpp-run -e entry --entry-point-result=void -print --nano-kernels --gemm-unroll=16,16,16 --registerBlocking=32,32,64 --splat-to-random -seed 123 --init-type quant %s > %t.2
 // RUN: fpcmp -r 0.001 %t.1 %t.2
 
@@ -28,9 +28,9 @@
 module {
   func.func @entry(
       %arg0: tensor<4x36x64x64xi8>,
-      %arg1: tensor<256xf8E8M0FNU>,
+      %arg1: tensor<256xf8E8M0FNU> {tpp.quant_scale},
       %arg2: tensor<24x36x16x64x4xi8>,
-      %arg3: tensor<1536xf8E8M0FNU>,
+      %arg3: tensor<1536xf8E8M0FNU> {tpp.quant_scale},
       %arg4: tensor<4x24x64x64xf32>) -> tensor<4x24x64x64xf32> {
 
     %c0_i32 = arith.constant 0 : i32

--- a/test/Integration/I8/AMX/tpp-run-gemm-requantize-correctness-i8-i8scale.mlir
+++ b/test/Integration/I8/AMX/tpp-run-gemm-requantize-correctness-i8-i8scale.mlir
@@ -15,14 +15,22 @@
 #map4 = affine_map<(d0, d1, d2, d3) -> (d0, 0, d2, 0)>
 #map5 = affine_map<(d0, d1, d2, d3) -> (d1, 0, d3, 0)>
 
+// Requantize an i8xi8->i32 GEMM back to i8 using narrow (f8E8M0FNU) scales.
+// The i32 accumulator is dequantized with the per-row input scale and
+// per-output-channel weight scale, rescaled with the per-output-channel output
+// scale, saturated to [-128, 127] and truncated to i8. Each narrow scale is
+// extended to f32 before being combined and applied.
 func.func @entry(
     %arg0: tensor<2x2x64x64xi8>,
-    %arg1: tensor<128xf32> {tpp.quant_scale},
+    %arg1: tensor<128xf8E8M0FNU> {tpp.quant_scale},
     %arg2: tensor<2x2x16x64x4xi8>,
-    %arg3: tensor<128xf32> {tpp.quant_scale},
-    %arg4: tensor<2x2x64x64xf32>) -> tensor<2x2x64x64xf32> {
+    %arg3: tensor<128xf8E8M0FNU> {tpp.quant_scale},
+    %arg4: tensor<128xf8E8M0FNU> {tpp.quant_scale},
+    %arg5: tensor<2x2x64x64xi8>) -> tensor<2x2x64x64xi8> {
 
   %c0_i32 = arith.constant 0 : i32
+  %lo = arith.constant -1.280000e+02 : f32
+  %hi = arith.constant 1.270000e+02 : f32
 
   %0 = tensor.empty() : tensor<2x2x64x64xi32>
 
@@ -48,30 +56,44 @@ func.func @entry(
   %expanded_0 = tensor.expand_shape %arg1
       [[0, 1, 2, 3]]
       output_shape [2, 1, 64, 1]
-      : tensor<128xf32>
-     into tensor<2x1x64x1xf32>
+      : tensor<128xf8E8M0FNU>
+     into tensor<2x1x64x1xf8E8M0FNU>
 
   %expanded_1 = tensor.expand_shape %arg3
       [[0, 1, 2, 3]]
       output_shape [2, 1, 64, 1]
-      : tensor<128xf32>
-     into tensor<2x1x64x1xf32>
+      : tensor<128xf8E8M0FNU>
+     into tensor<2x1x64x1xf8E8M0FNU>
+
+  %expanded_2 = tensor.expand_shape %arg4
+      [[0, 1, 2, 3]]
+      output_shape [2, 1, 64, 1]
+      : tensor<128xf8E8M0FNU>
+     into tensor<2x1x64x1xf8E8M0FNU>
 
   %3 = linalg.generic {
-      indexing_maps = [#map3, #map4, #map5, #map3],
+      indexing_maps = [#map3, #map4, #map5, #map5, #map3],
       iterator_types = ["parallel", "parallel", "parallel", "parallel"]
     }
-    ins(%2, %expanded_0, %expanded_1
+    ins(%2, %expanded_0, %expanded_1, %expanded_2
         : tensor<2x2x64x64xi32>,
-          tensor<2x1x64x1xf32>,
-          tensor<2x1x64x1xf32>)
-    outs(%arg4 : tensor<2x2x64x64xf32>) {
-  ^bb0(%in: i32, %in_2: f32, %in_3: f32, %out: f32):
-    %4 = arith.mulf %in_2, %in_3 : f32
-    %5 = arith.sitofp %in : i32 to f32
-    %6 = arith.mulf %5, %4 : f32
-    linalg.yield %6 : f32
-  } -> tensor<2x2x64x64xf32>
+          tensor<2x1x64x1xf8E8M0FNU>,
+          tensor<2x1x64x1xf8E8M0FNU>,
+          tensor<2x1x64x1xf8E8M0FNU>)
+    outs(%arg5 : tensor<2x2x64x64xi8>) {
+  ^bb0(%in: i32, %inS: f8E8M0FNU, %wS: f8E8M0FNU, %oS: f8E8M0FNU, %out: i8):
+    %4 = arith.sitofp %in : i32 to f32
+    %5 = arith.extf %inS : f8E8M0FNU to f32
+    %6 = arith.extf %wS : f8E8M0FNU to f32
+    %7 = arith.extf %oS : f8E8M0FNU to f32
+    %8 = arith.mulf %5, %6 : f32
+    %9 = arith.mulf %8, %7 : f32
+    %10 = arith.mulf %4, %9 : f32
+    %11 = arith.maximumf %10, %lo : f32
+    %12 = arith.minimumf %11, %hi : f32
+    %13 = arith.fptosi %12 : f32 to i8
+    linalg.yield %13 : i8
+  } -> tensor<2x2x64x64xi8>
 
-  return %3 : tensor<2x2x64x64xf32>
+  return %3 : tensor<2x2x64x64xi8>
 }

--- a/test/Integration/I8/AMX/tpp-run-gemm-requantize-correctness-i8.mlir
+++ b/test/Integration/I8/AMX/tpp-run-gemm-requantize-correctness-i8.mlir
@@ -15,14 +15,21 @@
 #map4 = affine_map<(d0, d1, d2, d3) -> (d0, 0, d2, 0)>
 #map5 = affine_map<(d0, d1, d2, d3) -> (d1, 0, d3, 0)>
 
+// Requantize an i8xi8->i32 GEMM back to i8. The i32 accumulator is dequantized
+// with the per-row input scale and per-output-channel weight scale, rescaled
+// with the per-output-channel output scale, saturated to [-128, 127] and
+// truncated to i8.
 func.func @entry(
     %arg0: tensor<2x2x64x64xi8>,
     %arg1: tensor<128xf32> {tpp.quant_scale},
     %arg2: tensor<2x2x16x64x4xi8>,
     %arg3: tensor<128xf32> {tpp.quant_scale},
-    %arg4: tensor<2x2x64x64xf32>) -> tensor<2x2x64x64xf32> {
+    %arg4: tensor<128xf32> {tpp.quant_scale},
+    %arg5: tensor<2x2x64x64xi8>) -> tensor<2x2x64x64xi8> {
 
   %c0_i32 = arith.constant 0 : i32
+  %lo = arith.constant -1.280000e+02 : f32
+  %hi = arith.constant 1.270000e+02 : f32
 
   %0 = tensor.empty() : tensor<2x2x64x64xi32>
 
@@ -57,21 +64,32 @@ func.func @entry(
       : tensor<128xf32>
      into tensor<2x1x64x1xf32>
 
+  %expanded_2 = tensor.expand_shape %arg4
+      [[0, 1, 2, 3]]
+      output_shape [2, 1, 64, 1]
+      : tensor<128xf32>
+     into tensor<2x1x64x1xf32>
+
   %3 = linalg.generic {
-      indexing_maps = [#map3, #map4, #map5, #map3],
+      indexing_maps = [#map3, #map4, #map5, #map5, #map3],
       iterator_types = ["parallel", "parallel", "parallel", "parallel"]
     }
-    ins(%2, %expanded_0, %expanded_1
+    ins(%2, %expanded_0, %expanded_1, %expanded_2
         : tensor<2x2x64x64xi32>,
           tensor<2x1x64x1xf32>,
+          tensor<2x1x64x1xf32>,
           tensor<2x1x64x1xf32>)
-    outs(%arg4 : tensor<2x2x64x64xf32>) {
-  ^bb0(%in: i32, %in_2: f32, %in_3: f32, %out: f32):
-    %4 = arith.mulf %in_2, %in_3 : f32
-    %5 = arith.sitofp %in : i32 to f32
-    %6 = arith.mulf %5, %4 : f32
-    linalg.yield %6 : f32
-  } -> tensor<2x2x64x64xf32>
+    outs(%arg5 : tensor<2x2x64x64xi8>) {
+  ^bb0(%in: i32, %inS: f32, %wS: f32, %oS: f32, %out: i8):
+    %4 = arith.sitofp %in : i32 to f32
+    %5 = arith.mulf %inS, %wS : f32
+    %6 = arith.mulf %5, %oS : f32
+    %7 = arith.mulf %4, %6 : f32
+    %8 = arith.maximumf %7, %lo : f32
+    %9 = arith.minimumf %8, %hi : f32
+    %10 = arith.fptosi %9 : f32 to i8
+    linalg.yield %10 : i8
+  } -> tensor<2x2x64x64xi8>
 
-  return %3 : tensor<2x2x64x64xf32>
+  return %3 : tensor<2x2x64x64xi8>
 }

--- a/test/Integration/MLIRGen/mlir-gen-matmul.mlir
+++ b/test/Integration/MLIRGen/mlir-gen-matmul.mlir
@@ -12,6 +12,10 @@
 // RUN: mlir-gen --kernel=args --seed=0 --data-type=mx-f32-i8 --batch=128 --layers=2304,768 --quant-type=quantize 2>&1 | FileCheck %s --check-prefix=MXF32I8-QUANT
 // RUN: mlir-gen --kernel=args --seed=0 --data-type=mx-i8-f32 --batch=4096 --layers=8192,4096 --quant-type=dequantize --output=generic --tiles=32,32,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=MXI8F32-PACKED-DEQUANT
 // RUN: mlir-gen --kernel=args --seed=0 --data-type=mx-i8-f32 --batch=128 --layers=2304,768 --quant-type=dequantize --scale-type=f8E8M0FNU --tiles=32,32,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=MXI8-I8SCALE-PACKED-DEQUANT
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=mx-i8 --batch=128 --layers=2304,768 --quant-type=quantize 2>&1 | FileCheck %s --check-prefix=MXI8-REQUANT
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=mx-i8 --batch=128 --layers=2304,768 --quant-type=quantize --tiles=32,32,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=MXI8-REQUANT-PACKED
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=mx-i8 --batch=128 --layers=2304,768 --quant-type=quantize --scale-type=f8E8M0FNU 2>&1 | FileCheck %s --check-prefix=MXI8-REQUANT-I8SCALE
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=mx-i8 --batch=128 --layers=2304,768 --quant-type=quantize --scale-type=f8E8M0FNU --tiles=32,32,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=MXI8-REQUANT-I8SCALE-PACKED
 
 
 // FP32: // RUN{{.*}}tpp-run %s -n {{\d*}}
@@ -152,9 +156,9 @@
 // MXBF16-DEQUANT-DAG: #[[$ATTR_5:.+]] = affine_map<(d0, d1) -> (d1)>
 // MXBF16-DEQUANT-LABEL:   func.func @entry(
 // MXBF16-DEQUANT-SAME:                     %arg0: tensor<128x2304xbf16>,
-// MXBF16-DEQUANT-SAME:                     %arg1: tensor<128xf32>,
+// MXBF16-DEQUANT-SAME:                     %arg1: tensor<128xf32> {tpp.quant_scale},
 // MXBF16-DEQUANT-SAME:                     %arg2: tensor<2304x768xbf16>,
-// MXBF16-DEQUANT-SAME:                     %arg3: tensor<768xf32>,
+// MXBF16-DEQUANT-SAME:                     %arg3: tensor<768xf32> {tpp.quant_scale},
 // MXBF16-DEQUANT-SAME:                     %arg4: tensor<128x768xf32>) -> tensor<128x768xf32> {
 // MXBF16-DEQUANT:           linalg.contract indexing_maps = [#[[$ATTR_0]], #[[$ATTR_1]], #[[$ATTR_2]]]
 // MXBF16-DEQUANT:           linalg.generic  {indexing_maps = [#[[$ATTR_3]], #[[$ATTR_4]], #[[$ATTR_5]], #[[$ATTR_3]]], iterator_types = ["parallel", "parallel"]}
@@ -170,9 +174,9 @@
 // MXI8F32-DEQUANT-DAG: #[[$ATTR_5:.+]] = affine_map<(d0, d1) -> (d1)>
 // MXI8F32-DEQUANT-LABEL:   func.func @entry(
 // MXI8F32-DEQUANT-SAME:                     %arg0: tensor<128x2304xi8>,
-// MXI8F32-DEQUANT-SAME:                     %arg1: tensor<128xf32>,
+// MXI8F32-DEQUANT-SAME:                     %arg1: tensor<128xf32> {tpp.quant_scale},
 // MXI8F32-DEQUANT-SAME:                     %arg2: tensor<2304x768xi8>,
-// MXI8F32-DEQUANT-SAME:                     %arg3: tensor<768xf32>,
+// MXI8F32-DEQUANT-SAME:                     %arg3: tensor<768xf32> {tpp.quant_scale},
 // MXI8F32-DEQUANT-SAME:                     %arg4: tensor<128x768xf32>) -> tensor<128x768xf32> {
 // MXI8F32-DEQUANT:           linalg.contract indexing_maps = [#[[$ATTR_0:.+]], #[[$ATTR_1:.+]], #[[$ATTR_2:.+]]]
 // MXI8F32-DEQUANT:           linalg.generic  {indexing_maps = [#[[$ATTR_3:.+]], #[[$ATTR_4:.+]], #[[$ATTR_5:.+]], #[[$ATTR_3:.+]]], iterator_types = ["parallel", "parallel"]}
@@ -213,6 +217,143 @@
 // MXF32I8-QUANT:               arith.fptosi
 
 
+// Requantize i8xi8->i32 Gemm output back to i8. The i32 accumulator is
+// dequantized with the per-row input scale and per-output-channel weight scale,
+// then rescaled with the per-output-channel output scale and saturated to i8.
+
+// MXI8-REQUANT: #map = affine_map<(d0, d1, d2) -> (d0, d2)>
+// MXI8-REQUANT: #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+// MXI8-REQUANT: #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+// MXI8-REQUANT: #map3 = affine_map<(d0, d1) -> (d0, d1)>
+// MXI8-REQUANT: #map4 = affine_map<(d0, d1) -> (d0)>
+// MXI8-REQUANT: #map5 = affine_map<(d0, d1) -> (d1)>
+// MXI8-REQUANT-LABEL:   func.func @entry(
+// MXI8-REQUANT-SAME:                     %[[ARG0:[a-z0-9_]+]]: tensor<128x2304xi8>,
+// MXI8-REQUANT-SAME:                     %[[ARG1:[a-z0-9_]+]]: tensor<128xf32> {tpp.quant_scale},
+// MXI8-REQUANT-SAME:                     %[[ARG2:[a-z0-9_]+]]: tensor<2304x768xi8>,
+// MXI8-REQUANT-SAME:                     %[[ARG3:[a-z0-9_]+]]: tensor<768xf32> {tpp.quant_scale},
+// MXI8-REQUANT-SAME:                     %[[ARG4:[a-z0-9_]+]]: tensor<768xf32> {tpp.quant_scale},
+// MXI8-REQUANT-SAME:                     %[[ARG5:[a-z0-9_]+]]: tensor<128x768xi8>) -> tensor<128x768xi8> {
+// MXI8-REQUANT:           %[[ZERO:.*]] = arith.constant 0 : i32
+// MXI8-REQUANT:           linalg.fill ins(%[[ZERO]] : i32){{.*}} -> tensor<128x768xi32>
+// MXI8-REQUANT:           linalg.contract indexing_maps = [#map, #map1, #map2] ins(%[[ARG0]], %[[ARG2]] : tensor<128x2304xi8>, tensor<2304x768xi8>) outs({{.*}} : tensor<128x768xi32>) -> tensor<128x768xi32>
+// MXI8-REQUANT:           %[[LOW:.*]] = arith.constant -1.280000e+02 : f32
+// MXI8-REQUANT:           %[[HIGH:.*]] = arith.constant 1.270000e+02 : f32
+// MXI8-REQUANT:           linalg.generic {indexing_maps = [#map3, #map4, #map5, #map5, #map3], iterator_types = ["parallel", "parallel"]} ins({{.*}}, %[[ARG1]], %[[ARG3]], %[[ARG4]] : tensor<128x768xi32>, tensor<128xf32>, tensor<768xf32>, tensor<768xf32>) outs(%[[ARG5]] : tensor<128x768xi8>) {
+// MXI8-REQUANT:           ^bb0(%[[IN:.*]]: i32, %[[INS:.*]]: f32, %[[WS:.*]]: f32, %[[OS:.*]]: f32, %[[OUT:.*]]: i8):
+// MXI8-REQUANT:             %[[F:.*]] = arith.sitofp %[[IN]] : i32 to f32
+// MXI8-REQUANT:             %[[SCALE0:.*]] = arith.mulf %[[INS]], %[[WS]] : f32
+// MXI8-REQUANT:             %[[SCALE1:.*]] = arith.mulf %[[SCALE0]], %[[OS]] : f32
+// MXI8-REQUANT:             %[[MUL:.*]] = arith.mulf %[[F]], %[[SCALE1]] : f32
+// MXI8-REQUANT:             %[[MAX:.*]] = arith.maximumf %[[MUL]], %[[LOW]] : f32
+// MXI8-REQUANT:             %[[MIN:.*]] = arith.minimumf %[[MAX]], %[[HIGH]] : f32
+// MXI8-REQUANT:             %[[I8:.*]] = arith.fptosi %[[MIN]] : f32 to i8
+// MXI8-REQUANT:             linalg.yield %[[I8]] : i8
+// MXI8-REQUANT:           } -> tensor<128x768xi8>
+
+
+// MXI8-REQUANT-PACKED: #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6, d3)>
+// MXI8-REQUANT-PACKED: #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6, d5, d3)>
+// MXI8-REQUANT-PACKED: #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+// MXI8-REQUANT-PACKED: #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// MXI8-REQUANT-PACKED: #map4 = affine_map<(d0, d1, d2, d3) -> (d0, 0, d2, 0)>
+// MXI8-REQUANT-PACKED: #map5 = affine_map<(d0, d1, d2, d3) -> (d1, 0, d3, 0)>
+// MXI8-REQUANT-PACKED-LABEL:   func.func @entry(
+// MXI8-REQUANT-PACKED-SAME:                     %[[ARG0:[a-z0-9_]+]]: tensor<4x36x32x64xi8>,
+// MXI8-REQUANT-PACKED-SAME:                     %[[ARG1:[a-z0-9_]+]]: tensor<128xf32> {tpp.quant_scale},
+// MXI8-REQUANT-PACKED-SAME:                     %[[ARG2:[a-z0-9_]+]]: tensor<24x36x16x32x4xi8>,
+// MXI8-REQUANT-PACKED-SAME:                     %[[ARG3:[a-z0-9_]+]]: tensor<768xf32> {tpp.quant_scale},
+// MXI8-REQUANT-PACKED-SAME:                     %[[ARG4:[a-z0-9_]+]]: tensor<768xf32> {tpp.quant_scale},
+// MXI8-REQUANT-PACKED-SAME:                     %[[ARG5:[a-z0-9_]+]]: tensor<4x24x32x32xi8>) -> tensor<4x24x32x32xi8> {
+// MXI8-REQUANT-PACKED:           linalg.fill{{.*}} -> tensor<4x24x32x32xi32>
+// MXI8-REQUANT-PACKED:           tensor.expand_shape %[[ARG0]]
+// MXI8-REQUANT-PACKED:           linalg.contract indexing_maps = [#map, #map1, #map2] ins({{.*}}, %[[ARG2]] : tensor<4x36x32x16x4xi8>, tensor<24x36x16x32x4xi8>) outs({{.*}} : tensor<4x24x32x32xi32>) -> tensor<4x24x32x32xi32>
+// MXI8-REQUANT-PACKED:           tensor.expand_shape %[[ARG1]] {{.*}} output_shape [4, 1, 32, 1] : tensor<128xf32> into tensor<4x1x32x1xf32>
+// MXI8-REQUANT-PACKED:           tensor.expand_shape %[[ARG3]] {{.*}} output_shape [24, 1, 32, 1] : tensor<768xf32> into tensor<24x1x32x1xf32>
+// MXI8-REQUANT-PACKED:           tensor.expand_shape %[[ARG4]] {{.*}} output_shape [24, 1, 32, 1] : tensor<768xf32> into tensor<24x1x32x1xf32>
+// MXI8-REQUANT-PACKED:           linalg.generic {indexing_maps = [#map3, #map4, #map5, #map5, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins({{.*}} : tensor<4x24x32x32xi32>, tensor<4x1x32x1xf32>, tensor<24x1x32x1xf32>, tensor<24x1x32x1xf32>) outs(%[[ARG5]] : tensor<4x24x32x32xi8>) {
+// MXI8-REQUANT-PACKED:             arith.sitofp
+// MXI8-REQUANT-PACKED:             arith.mulf
+// MXI8-REQUANT-PACKED:             arith.mulf
+// MXI8-REQUANT-PACKED:             arith.mulf
+// MXI8-REQUANT-PACKED:             arith.maximumf
+// MXI8-REQUANT-PACKED:             arith.minimumf
+// MXI8-REQUANT-PACKED:             arith.fptosi
+// MXI8-REQUANT-PACKED:             linalg.yield
+
+
+// Requantize with narrow (f8E8M0FNU) scales. The scales are extended to f32
+// before being combined and applied to the i32 accumulator.
+
+// MXI8-REQUANT-I8SCALE: #map = affine_map<(d0, d1, d2) -> (d0, d2)>
+// MXI8-REQUANT-I8SCALE: #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+// MXI8-REQUANT-I8SCALE: #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+// MXI8-REQUANT-I8SCALE: #map3 = affine_map<(d0, d1) -> (d0, d1)>
+// MXI8-REQUANT-I8SCALE: #map4 = affine_map<(d0, d1) -> (d0)>
+// MXI8-REQUANT-I8SCALE: #map5 = affine_map<(d0, d1) -> (d1)>
+// MXI8-REQUANT-I8SCALE-LABEL:   func.func @entry(
+// MXI8-REQUANT-I8SCALE-SAME:                     %[[ARG0:[a-z0-9_]+]]: tensor<128x2304xi8>,
+// MXI8-REQUANT-I8SCALE-SAME:                     %[[ARG1:[a-z0-9_]+]]: tensor<128xf8E8M0FNU> {tpp.quant_scale},
+// MXI8-REQUANT-I8SCALE-SAME:                     %[[ARG2:[a-z0-9_]+]]: tensor<2304x768xi8>,
+// MXI8-REQUANT-I8SCALE-SAME:                     %[[ARG3:[a-z0-9_]+]]: tensor<768xf8E8M0FNU> {tpp.quant_scale},
+// MXI8-REQUANT-I8SCALE-SAME:                     %[[ARG4:[a-z0-9_]+]]: tensor<768xf8E8M0FNU> {tpp.quant_scale},
+// MXI8-REQUANT-I8SCALE-SAME:                     %[[ARG5:[a-z0-9_]+]]: tensor<128x768xi8>) -> tensor<128x768xi8> {
+// MXI8-REQUANT-I8SCALE:           %[[ZERO:.*]] = arith.constant 0 : i32
+// MXI8-REQUANT-I8SCALE:           linalg.fill ins(%[[ZERO]] : i32){{.*}} -> tensor<128x768xi32>
+// MXI8-REQUANT-I8SCALE:           linalg.contract indexing_maps = [#map, #map1, #map2] ins(%[[ARG0]], %[[ARG2]] : tensor<128x2304xi8>, tensor<2304x768xi8>) outs({{.*}} : tensor<128x768xi32>) -> tensor<128x768xi32>
+// MXI8-REQUANT-I8SCALE:           %[[LOW:.*]] = arith.constant -1.280000e+02 : f32
+// MXI8-REQUANT-I8SCALE:           %[[HIGH:.*]] = arith.constant 1.270000e+02 : f32
+// MXI8-REQUANT-I8SCALE:           linalg.generic {indexing_maps = [#map3, #map4, #map5, #map5, #map3], iterator_types = ["parallel", "parallel"]} ins({{.*}}, %[[ARG1]], %[[ARG3]], %[[ARG4]] : tensor<128x768xi32>, tensor<128xf8E8M0FNU>, tensor<768xf8E8M0FNU>, tensor<768xf8E8M0FNU>) outs(%[[ARG5]] : tensor<128x768xi8>) {
+// MXI8-REQUANT-I8SCALE:           ^bb0(%[[IN:.*]]: i32, %[[INS:.*]]: f8E8M0FNU, %[[WS:.*]]: f8E8M0FNU, %[[OS:.*]]: f8E8M0FNU, %[[OUT:.*]]: i8):
+// MXI8-REQUANT-I8SCALE:             %[[F:.*]] = arith.sitofp %[[IN]] : i32 to f32
+// MXI8-REQUANT-I8SCALE:             %[[EINS:.*]] = arith.extf %[[INS]] : f8E8M0FNU to f32
+// MXI8-REQUANT-I8SCALE:             %[[EWS:.*]] = arith.extf %[[WS]] : f8E8M0FNU to f32
+// MXI8-REQUANT-I8SCALE:             %[[EOS:.*]] = arith.extf %[[OS]] : f8E8M0FNU to f32
+// MXI8-REQUANT-I8SCALE:             %[[SCALE0:.*]] = arith.mulf %[[EINS]], %[[EWS]] : f32
+// MXI8-REQUANT-I8SCALE:             %[[SCALE1:.*]] = arith.mulf %[[SCALE0]], %[[EOS]] : f32
+// MXI8-REQUANT-I8SCALE:             %[[MUL:.*]] = arith.mulf %[[F]], %[[SCALE1]] : f32
+// MXI8-REQUANT-I8SCALE:             %[[MAX:.*]] = arith.maximumf %[[MUL]], %[[LOW]] : f32
+// MXI8-REQUANT-I8SCALE:             %[[MIN:.*]] = arith.minimumf %[[MAX]], %[[HIGH]] : f32
+// MXI8-REQUANT-I8SCALE:             %[[I8:.*]] = arith.fptosi %[[MIN]] : f32 to i8
+// MXI8-REQUANT-I8SCALE:             linalg.yield %[[I8]] : i8
+// MXI8-REQUANT-I8SCALE:           } -> tensor<128x768xi8>
+
+
+// Packed (tiled + VNNI) requantize with narrow (f8E8M0FNU) scales.
+
+// MXI8-REQUANT-I8SCALE-PACKED: #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6, d3)>
+// MXI8-REQUANT-I8SCALE-PACKED: #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6, d5, d3)>
+// MXI8-REQUANT-I8SCALE-PACKED: #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+// MXI8-REQUANT-I8SCALE-PACKED: #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// MXI8-REQUANT-I8SCALE-PACKED: #map4 = affine_map<(d0, d1, d2, d3) -> (d0, 0, d2, 0)>
+// MXI8-REQUANT-I8SCALE-PACKED: #map5 = affine_map<(d0, d1, d2, d3) -> (d1, 0, d3, 0)>
+// MXI8-REQUANT-I8SCALE-PACKED-LABEL:   func.func @entry(
+// MXI8-REQUANT-I8SCALE-PACKED-SAME:                     %[[ARG0:[a-z0-9_]+]]: tensor<4x36x32x64xi8>,
+// MXI8-REQUANT-I8SCALE-PACKED-SAME:                     %[[ARG1:[a-z0-9_]+]]: tensor<128xf8E8M0FNU> {tpp.quant_scale},
+// MXI8-REQUANT-I8SCALE-PACKED-SAME:                     %[[ARG2:[a-z0-9_]+]]: tensor<24x36x16x32x4xi8>,
+// MXI8-REQUANT-I8SCALE-PACKED-SAME:                     %[[ARG3:[a-z0-9_]+]]: tensor<768xf8E8M0FNU> {tpp.quant_scale},
+// MXI8-REQUANT-I8SCALE-PACKED-SAME:                     %[[ARG4:[a-z0-9_]+]]: tensor<768xf8E8M0FNU> {tpp.quant_scale},
+// MXI8-REQUANT-I8SCALE-PACKED-SAME:                     %[[ARG5:[a-z0-9_]+]]: tensor<4x24x32x32xi8>) -> tensor<4x24x32x32xi8> {
+// MXI8-REQUANT-I8SCALE-PACKED:           linalg.fill{{.*}} -> tensor<4x24x32x32xi32>
+// MXI8-REQUANT-I8SCALE-PACKED:           tensor.expand_shape %[[ARG0]]
+// MXI8-REQUANT-I8SCALE-PACKED:           linalg.contract indexing_maps = [#map, #map1, #map2] ins({{.*}}, %[[ARG2]] : tensor<4x36x32x16x4xi8>, tensor<24x36x16x32x4xi8>) outs({{.*}} : tensor<4x24x32x32xi32>) -> tensor<4x24x32x32xi32>
+// MXI8-REQUANT-I8SCALE-PACKED:           tensor.expand_shape %[[ARG1]] {{.*}} output_shape [4, 1, 32, 1] : tensor<128xf8E8M0FNU> into tensor<4x1x32x1xf8E8M0FNU>
+// MXI8-REQUANT-I8SCALE-PACKED:           tensor.expand_shape %[[ARG3]] {{.*}} output_shape [24, 1, 32, 1] : tensor<768xf8E8M0FNU> into tensor<24x1x32x1xf8E8M0FNU>
+// MXI8-REQUANT-I8SCALE-PACKED:           tensor.expand_shape %[[ARG4]] {{.*}} output_shape [24, 1, 32, 1] : tensor<768xf8E8M0FNU> into tensor<24x1x32x1xf8E8M0FNU>
+// MXI8-REQUANT-I8SCALE-PACKED:           linalg.generic {indexing_maps = [#map3, #map4, #map5, #map5, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins({{.*}} : tensor<4x24x32x32xi32>, tensor<4x1x32x1xf8E8M0FNU>, tensor<24x1x32x1xf8E8M0FNU>, tensor<24x1x32x1xf8E8M0FNU>) outs(%[[ARG5]] : tensor<4x24x32x32xi8>) {
+// MXI8-REQUANT-I8SCALE-PACKED:             arith.sitofp
+// MXI8-REQUANT-I8SCALE-PACKED:             arith.extf {{.*}} f8E8M0FNU to f32
+// MXI8-REQUANT-I8SCALE-PACKED:             arith.extf {{.*}} f8E8M0FNU to f32
+// MXI8-REQUANT-I8SCALE-PACKED:             arith.extf {{.*}} f8E8M0FNU to f32
+// MXI8-REQUANT-I8SCALE-PACKED:             arith.mulf
+// MXI8-REQUANT-I8SCALE-PACKED:             arith.mulf
+// MXI8-REQUANT-I8SCALE-PACKED:             arith.mulf
+// MXI8-REQUANT-I8SCALE-PACKED:             arith.maximumf
+// MXI8-REQUANT-I8SCALE-PACKED:             arith.minimumf
+// MXI8-REQUANT-I8SCALE-PACKED:             arith.fptosi
+// MXI8-REQUANT-I8SCALE-PACKED:             linalg.yield
+
+
 // MXI8F32-PACKED-DEQUANT-DAG: #[[$ATTR_0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6, d3)>
 // MXI8F32-PACKED-DEQUANT-DAG: #[[$ATTR_1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6, d5, d3)>
 // MXI8F32-PACKED-DEQUANT-DAG: #[[$ATTR_2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
@@ -220,8 +361,8 @@
 // MXI8F32-PACKED-DEQUANT-DAG: #[[$ATTR_4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, 0, d2, 0)>
 // MXI8F32-PACKED-DEQUANT-LABEL:   func.func @entry(
 // MXI8F32-PACKED-DEQUANT-SAME:                     {{.*}}: tensor<128x128x32x64xi8>,
-// MXI8F32-PACKED-DEQUANT-SAME:                     {{.*}}: tensor<4096xf32>, {{.*}}: tensor<128x128x16x32x4xi8>,
-// MXI8F32-PACKED-DEQUANT-SAME:                     {{.*}}: tensor<4096xf32>,
+// MXI8F32-PACKED-DEQUANT-SAME:                     {{.*}}: tensor<4096xf32> {tpp.quant_scale}, {{.*}}: tensor<128x128x16x32x4xi8>,
+// MXI8F32-PACKED-DEQUANT-SAME:                     {{.*}}: tensor<4096xf32> {tpp.quant_scale},
 // MXI8F32-PACKED-DEQUANT-SAME:                     {{.*}}: tensor<128x128x32x32xf32>) -> tensor<128x128x32x32xf32> {
 
 // MXI8F32-PACKED-DEQUANT:           linalg.fill
@@ -244,9 +385,9 @@
 // MXI8-I8SCALE-DEQUANT-DAG: #[[$ATTR_5:.+]] = affine_map<(d0, d1) -> (d1)>
 // MXI8-I8SCALE-DEQUANT-LABEL:   func.func @entry(
 // MXI8-I8SCALE-DEQUANT-SAME:                     %[[ARG0:.*]]: tensor<128x2304xi8>,
-// MXI8-I8SCALE-DEQUANT-SAME:                     %[[ARG1:.*]]: tensor<128xf8E8M0FNU>,
+// MXI8-I8SCALE-DEQUANT-SAME:                     %[[ARG1:.*]]: tensor<128xf8E8M0FNU> {tpp.quant_scale},
 // MXI8-I8SCALE-DEQUANT-SAME:                     %[[ARG2:.*]]: tensor<2304x768xi8>,
-// MXI8-I8SCALE-DEQUANT-SAME:                     %[[ARG3:.*]]: tensor<768xf8E8M0FNU>,
+// MXI8-I8SCALE-DEQUANT-SAME:                     %[[ARG3:.*]]: tensor<768xf8E8M0FNU> {tpp.quant_scale},
 // MXI8-I8SCALE-DEQUANT-SAME:                     %[[ARG4:.*]]: tensor<128x768xf32>) -> tensor<128x768xf32> {
 // MXI8-I8SCALE-DEQUANT:           arith.constant 0 : i32
 // MXI8-I8SCALE-DEQUANT:           tensor.empty() : tensor<128x768xi32>
@@ -270,9 +411,9 @@
 // MXI8-I8SCALE-PACKED-DEQUANT-DAG: #[[$ATTR_5:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, 0, d3, 0)>
 // MXI8-I8SCALE-PACKED-DEQUANT-LABEL:   func.func @entry(
 // MXI8-I8SCALE-PACKED-DEQUANT-SAME:                     %[[ARG0:.*]]: tensor<4x36x32x64xi8>,
-// MXI8-I8SCALE-PACKED-DEQUANT-SAME:                     %[[ARG1:.*]]: tensor<128xf8E8M0FNU>,
+// MXI8-I8SCALE-PACKED-DEQUANT-SAME:                     %[[ARG1:.*]]: tensor<128xf8E8M0FNU> {tpp.quant_scale},
 // MXI8-I8SCALE-PACKED-DEQUANT-SAME:                     %[[ARG2:.*]]: tensor<24x36x16x32x4xi8>,
-// MXI8-I8SCALE-PACKED-DEQUANT-SAME:                     %[[ARG3:.*]]: tensor<768xf8E8M0FNU>,
+// MXI8-I8SCALE-PACKED-DEQUANT-SAME:                     %[[ARG3:.*]]: tensor<768xf8E8M0FNU> {tpp.quant_scale},
 // MXI8-I8SCALE-PACKED-DEQUANT-SAME:                     %[[ARG4:.*]]: tensor<4x24x32x32xf32>) -> tensor<4x24x32x32xf32> {
 // MXI8-I8SCALE-PACKED-DEQUANT:           arith.constant 0 : i32
 // MXI8-I8SCALE-PACKED-DEQUANT:           tensor.empty() : tensor<4x24x32x32xi32>

--- a/test/Integration/TPP/tpp-run-dequantize-quantize-correctness-i8-f32-i8.mlir
+++ b/test/Integration/TPP/tpp-run-dequantize-quantize-correctness-i8-f32-i8.mlir
@@ -136,7 +136,7 @@ module {
     return %castToi8_val, %pos_exp2_val : !twoDimi8, !oneDimf32
   }
 
-  func.func @entry(%input : !twoDimi8, %scale : !oneDimf32, %output : !twoDimi8) -> (!twoDimi8) {
+  func.func @entry(%input : !twoDimi8, %scale : !oneDimf32 {tpp.quant_scale}, %output : !twoDimi8) -> (!twoDimi8) {
     %c0_f32 = arith.constant 0.0 : f32
     %c0_i8 = arith.constant 0 : i8
     %c0 = arith.constant 0 : index

--- a/test/Integration/TPP/tpp-run-quant-initialize.mlir
+++ b/test/Integration/TPP/tpp-run-quant-initialize.mlir
@@ -19,7 +19,7 @@
 !oneDimScaleWeightf32 = tensor<4xf32>
 
 
-func.func @entry(%input : !twoDimInputi8, %iScale : !oneDimScaleInputf32, %weight : !twoDimWeighti8, %wScale : !oneDimScaleWeightf32) {
+func.func @entry(%input : !twoDimInputi8, %iScale : !oneDimScaleInputf32 {tpp.quant_scale}, %weight : !twoDimWeighti8, %wScale : !oneDimScaleWeightf32 {tpp.quant_scale}) {
   return
 }
 
@@ -39,7 +39,7 @@ func.func @entry(%input : !twoDimInputi8, %iScale : !oneDimScaleInputf32, %weigh
 // UNPACKED: ( 15, -48, 66, 1, -4, -31, 68, 82, 22, 15, 10, 30, -2, -53, -37, 70 )
 // UNPACKED: ( 0.00390625, 0.00390625, 0.0078125, 0.00195312, 0.00390625, 0.0078125, 0.00390625, 0.000976562, 0.00390625, 0.00390625, 0.00390625, 0.0078125, 0.0078125, 0.00195312, 0.00390625, 0.00390625 )
 
-func.func @unpacked(%arg0: tensor<4x8xi8>, %arg1: tensor<4xf32>, %arg2: tensor<8x16xi8>, %arg3: tensor<16xf32>) {
+func.func @unpacked(%arg0: tensor<4x8xi8>, %arg1: tensor<4xf32> {tpp.quant_scale}, %arg2: tensor<8x16xi8>, %arg3: tensor<16xf32> {tpp.quant_scale}) {
   return
 }
 
@@ -85,6 +85,6 @@ func.func @unpacked(%arg0: tensor<4x8xi8>, %arg1: tensor<4xf32>, %arg2: tensor<8
 // PACKED: ( -2, -53, -37, 70 )
 // PACKED: ( 0.00390625, 0.00390625, 0.0078125, 0.00195312, 0.00390625, 0.0078125, 0.00390625, 0.000976562, 0.00390625, 0.00390625, 0.00390625, 0.0078125, 0.0078125, 0.00195312, 0.00390625, 0.00390625 )
 
-func.func @packed(%arg0: tensor<2x2x2x4xi8>, %arg1: tensor<4xf32>, %arg2: tensor<8x2x1x2x4xi8>, %arg3: tensor<16xf32>) {
+func.func @packed(%arg0: tensor<2x2x2x4xi8>, %arg1: tensor<4xf32> {tpp.quant_scale}, %arg2: tensor<8x2x1x2x4xi8>, %arg3: tensor<16xf32> {tpp.quant_scale}) {
   return
 }

--- a/test/Passes/convert-to-streaming-store.mlir
+++ b/test/Passes/convert-to-streaming-store.mlir
@@ -1,0 +1,47 @@
+// RUN: tpp-opt %s --convert-to-streaming-store --split-input-file | FileCheck %s
+
+// A 1-D write into a destination buffer that is never read back must become a
+// nontemporal vector.store.
+
+// CHECK-LABEL: func.func @streaming_store
+func.func @streaming_store(%v: vector<64xi8>, %c: memref<64x64xi8>) {
+  %c0 = arith.constant 0 : index
+  %sv = memref.subview %c[0, 0] [1, 64] [1, 1]
+    : memref<64x64xi8> to memref<64xi8, strided<[1], offset: 0>>
+  // CHECK: vector.store %{{.*}} {nontemporal = true} : memref<64xi8, strided<[1]>>, vector<64xi8>
+  // CHECK-NOT: vector.transfer_write
+  vector.transfer_write %v, %sv[%c0] {in_bounds = [true]}
+    : vector<64xi8>, memref<64xi8, strided<[1], offset: 0>>
+  return
+}
+
+// -----
+
+// A destination buffer that is later read back must not be streamed.
+
+// CHECK-LABEL: func.func @read_back
+func.func @read_back(%v: vector<64xi8>, %c: memref<64xi8>) -> vector<64xi8> {
+  %c0 = arith.constant 0 : index
+  %pad = arith.constant 0 : i8
+  // CHECK: vector.transfer_write {{.*}} : vector<64xi8>, memref<64xi8>
+  // CHECK-NOT: nontemporal
+  vector.transfer_write %v, %c[%c0] {in_bounds = [true]}
+    : vector<64xi8>, memref<64xi8>
+  %r = vector.transfer_read %c[%c0], %pad {in_bounds = [true]}
+    : memref<64xi8>, vector<64xi8>
+  return %r : vector<64xi8>
+}
+
+// -----
+
+// Multi-dimensional writes are left untouched: only rank-1 stores lower to LLVM.
+
+// CHECK-LABEL: func.func @rank2_write_only
+func.func @rank2_write_only(%v: vector<1x64xi8>, %c: memref<1x64xi8>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: vector.transfer_write {{.*}} : vector<1x64xi8>, memref<1x64xi8>
+  // CHECK-NOT: nontemporal
+  vector.transfer_write %v, %c[%c0, %c0] {in_bounds = [true, true]}
+    : vector<1x64xi8>, memref<1x64xi8>
+  return
+}

--- a/tools/mlir-gen/MLIRGen.cpp
+++ b/tools/mlir-gen/MLIRGen.cpp
@@ -256,6 +256,7 @@ MLIRGenerator::MLIRGenerator(StringRef outputOpKindStr, StringRef kernelStr,
   assert(scaleTypeOpt && "Unsupported scale type");
   dataTypes.inputScale = *scaleTypeOpt;
   dataTypes.weightScale = *scaleTypeOpt;
+  dataTypes.outputScale = *scaleTypeOpt;
 
   // Parse quantization type
   auto optQuantType =
@@ -311,6 +312,10 @@ MLIRGenerator::MLIRGenerator(StringRef outputOpKindStr, StringRef kernelStr,
   builder.setInsertionPoint(module);
 }
 
+bool MLIRGenerator::isRequantization() const {
+  return quantType == QuantizationType::Quant && dataTypes.input.isInteger(8);
+}
+
 void MLIRGenerator::getKernelTypes(KernelArgs &args) {
   // Input type, also first layer's input
   TensorType currentType = getShape({batch, layers.front()}, PACK_INPUT);
@@ -326,21 +331,34 @@ void MLIRGenerator::getKernelTypes(KernelArgs &args) {
     LayerArgs arg;
     arg.index = i;
     arg.input.type = currentType;
-    // Scale inputs are only needed for dequantization.
-    if (quantType == QuantizationType::Dequant)
+    // Scale inputs are needed for dequantization and requantization. In both
+    // cases the i32 accumulator is dequantized using the per-row input scale
+    // and the per-output-channel weight scale.
+    if (quantType == QuantizationType::Dequant || isRequantization())
       arg.inputScale.type = getShape({batch}, INPUT_SCALE);
     arg.weight.type = getShape({inputSize, outputSize}, PACK_WEIGHT);
-    if (quantType == QuantizationType::Dequant)
+    if (quantType == QuantizationType::Dequant || isRequantization())
       arg.weightScale.type = getShape({outputSize}, WEIGHT_SCALE);
+
     // TODO: Bias should be of accumulator type when it differs from the output
     // type AND we want to propagate the truncation through the element-wise ops.
     arg.bias.type = getShape({outputSize}, PACK_OUTPUT);
+
+    // Requantization additionally needs a per-output-channel output scale to
+    // convert the dequantized value back to i8.
+    if (isRequantization())
+      arg.outputScale.type = getShape({outputSize}, OUTPUT_SCALE);
 
     // For QuantDequant, such as F32->i8->F32, we need an intermediate type to
     // hold the quantized value.
     if (quantType == QuantizationType::QuantDequant) {
       arg.intermediate.type = getShape({batch, outputSize}, PACK_INTERMEDIATE);
       arg.output.type = getShape({batch, outputSize}, PACK_INPUT);
+    } else if (isRequantization()) {
+      // Requantized GEMM keeps the N x K output layout but stores i8 values.
+      auto packedOutTy = getShape({batch, outputSize}, PACK_OUTPUT);
+      arg.output.type =
+          RankedTensorType::get(packedOutTy.getShape(), dataTypes.input);
     } else {
       arg.output.type = getShape({batch, outputSize}, PACK_OUTPUT);
       arg.accumulator.type = getShape({batch, outputSize}, PACK_ACCUMULATOR);
@@ -391,9 +409,11 @@ Value MLIRGenerator::createLayer(LayerArgs &args) {
   if (quantType == QuantizationType::QuantDequant)
     return testQuantDequant(args, chain);
 
-  if (quantType == QuantizationType::Quant) {
+  if (isRequantization())
+      chain = requantizeGemm(args, chain);
+
+  if (quantType == QuantizationType::Quant && !isRequantization())
     chain = quantizeGemm(args, chain);
-  }
 
   if (quantType == QuantizationType::Dequant)
     chain = dequantizeGemm(args, chain);
@@ -435,12 +455,14 @@ void MLIRGenerator::createKernel() {
   SmallVector<Type, 1> inputTypes{firstArg.input.type};
   if (kernelType == KernelType::Args) {
     for (auto &layer : args) {
-      if (quantType == QuantizationType::Dequant)
+      if (quantType == QuantizationType::Dequant || isRequantization())
         inputTypes.push_back(layer.inputScale.type);
 
       inputTypes.push_back(layer.weight.type);
-      if (quantType == QuantizationType::Dequant)
+      if (quantType == QuantizationType::Dequant || isRequantization())
         inputTypes.push_back(layer.weightScale.type);
+      if (isRequantization())
+        inputTypes.push_back(layer.outputScale.type);
 
       if (enableBias)
         inputTypes.push_back(layer.bias.type);
@@ -481,13 +503,16 @@ void MLIRGenerator::createKernel() {
   //   * Model: input = arg, weights/bias = const, output = zero
   //   * Layer: input/weights/bias/output = args
   firstArg.input.value = func.getArgument(0);
-  // Scales are only needed for dequantization
-  if (quantType == QuantizationType::Dequant)
+  // Scales are needed for dequantization and requantization.
+  if (quantType == QuantizationType::Dequant || isRequantization()) {
+    func.setArgAttr(1, "tpp.quant_scale", builder.getUnitAttr());
     firstArg.inputScale.value = func.getArgument(1);
+  }
 
   // Argument position is input + N * { weight/bias } + output
   // First weight is at position 1, every two
-  unsigned argPos = !(quantType == QuantizationType::Dequant) ? 1 : 2;
+  unsigned argPos =
+      (quantType == QuantizationType::Dequant || isRequantization()) ? 2 : 1;
   // Caches the output to chain into the next layer's input
   Value lastOutput;
   for (auto &arg : args) {
@@ -498,8 +523,14 @@ void MLIRGenerator::createKernel() {
     // Initialize weights and biases
     if (kernelType == KernelType::Args) {
       arg.weight.value = func.getArgument(argPos++);
-      if (quantType == QuantizationType::Dequant)
+      if (quantType == QuantizationType::Dequant || isRequantization()) {
+        func.setArgAttr(argPos, "tpp.quant_scale", builder.getUnitAttr());
         arg.weightScale.value = func.getArgument(argPos++);
+      }
+      if (isRequantization()) {
+        func.setArgAttr(argPos, "tpp.quant_scale", builder.getUnitAttr());
+        arg.outputScale.value = func.getArgument(argPos++);
+      }
       if (enableBias)
         arg.bias.value = func.getArgument(argPos++);
       arg.output.value = func.getArgument(argPos++);
@@ -613,7 +644,11 @@ Value MLIRGenerator::lowerMatmul(LayerArgs &args) {
   auto shape = outputType.getShape();
 
   // Select the matmul accumulator tensor.
-  if (quantType == QuantizationType::Quant) {
+  if (isRequantization()) {
+    // i8xi8 GEMM accumulates into i32 before requantization back to i8.
+    args.accumulator.value = getZeroInitTensor(
+        RankedTensorType::get(shape, builder.getIntegerType(32)));
+  } else if (quantType == QuantizationType::Quant) {
     // Quantization casts the result later; accumulate in the input type.
     args.accumulator.value = getZeroInitTensor(
         RankedTensorType::get(shape, inputType.getElementType()));
@@ -627,7 +662,7 @@ Value MLIRGenerator::lowerMatmul(LayerArgs &args) {
     // Accumulator matches the output type; accumulate directly into it.
     args.accumulator.value = args.output.value;
   } else {
-    args.accumulator.value = getZeroInitTensor(args.accumulator.type);
+      args.accumulator.value = getZeroInitTensor(args.accumulator.type);
   }
 
   if (vnniPacked) {
@@ -667,6 +702,11 @@ Value MLIRGenerator::lowerMatmul(LayerArgs &args) {
       accumulator = lowerNamedMatmul(args, args.input.value);
       break;
   }
+
+  // Requantization consumes the raw i32 accumulator directly, so keep it as-is
+  // rather than truncating it to the i8 output type here.
+  if (isRequantization())
+    return accumulator;
 
   return downcastToOutput(builder, loc, accumulator, args.output.type);
 }
@@ -919,6 +959,146 @@ Value MLIRGenerator::quantizeGemm(LayerArgs &args, Value chain) {
   // TODO: A place holder for flops computation for quantization.
   computeMatmulFlops(inputShapedTy, outputShapedTy);
   return dquantRes;
+}
+
+Value MLIRGenerator::requantizeGemm(LayerArgs &args, Value chain) {
+  // Chain is the i32 GEMM accumulator to be requantized back to i8.
+  // Requantization first dequantizes the accumulator using the per-row input
+  // scale and the per-output-channel weight scale, then rescales it with the
+  // per-output-channel output scale and saturates to the signed i8 range:
+  //   out_i8 = clamp(round(acc_i32 * S_input * S_weight * S_output), -128, 127)
+  assert(chain && "Expected valid chain output from contract/gemm operation");
+
+  Value inputScale = args.inputScale.value;
+  Value weightScale = args.weightScale.value;
+  Value outputScale = args.outputScale.value;
+  Value output = args.output.value;
+
+  auto outputShapedTy = cast<ShapedType>(output.getType());
+  assert(outputShapedTy.getElementType().isInteger(8) &&
+         "Requantization output must be i8");
+
+  auto inputScaleTy = cast<ShapedType>(inputScale.getType());
+  assert(inputScaleTy.getRank() == 1 && "Input scale must be a vector");
+  assert(inputScaleTy.getElementType() == dataTypes.inputScale &&
+         "Input scale must be of scale type");
+  auto weightScaleTy = cast<ShapedType>(weightScale.getType());
+  assert(weightScaleTy.getRank() == 1 && "Weight scale must be a vector");
+  assert(weightScaleTy.getElementType() == dataTypes.weightScale &&
+         "Weight scale must be of scale type");
+  auto outputScaleTy = cast<ShapedType>(outputScale.getType());
+  assert(outputScaleTy.getRank() == 1 && "Output scale must be a vector");
+  assert(outputScaleTy.getElementType() == dataTypes.outputScale &&
+         "Output scale must be of scale type");
+
+  MLIRContext *ctx = &context;
+  // Input scale is per-row (batch); weight and output scales are per-output
+  // channel (K dimension).
+  auto dim0 = getAffineDimExpr(0, ctx);
+  auto dim1 = getAffineDimExpr(1, ctx);
+  AffineMap inputScaleMap = AffineMap::get(2, 0, {dim0}, ctx);
+  AffineMap weightScaleMap = AffineMap::get(2, 0, {dim1}, ctx);
+  AffineMap outputScaleMap = AffineMap::get(2, 0, {dim1}, ctx);
+  SmallVector<utils::IteratorType> iteratorTypes(2,
+                                                 utils::IteratorType::parallel);
+  SmallVector<AffineMap> maps = {getMap(chain, MAP_PARALLEL), inputScaleMap,
+                                 weightScaleMap, outputScaleMap,
+                                 getMap(output, MAP_PARALLEL)};
+
+  // If tiling is applied, expand each scale tensor to match the tiled output
+  // dimensions and broadcast over the remaining unit dimensions.
+  if (tiles.size() > 0) {
+    inputScale =
+        createExpandedScaleTensor(builder, loc, inputScale, tiles, true);
+    weightScale =
+        createExpandedScaleTensor(builder, loc, weightScale, tiles, false);
+    outputScale =
+        createExpandedScaleTensor(builder, loc, outputScale, tiles, false);
+
+    auto outputShape = outputShapedTy.getShape();
+    // Map an expanded scale tensor's dimensions onto the output dimensions,
+    // broadcasting unit-sized dimensions. Input scales start matching from the
+    // outermost (row) dimension, weight/output scales from the channel one.
+    auto createScaleAffineExprs = [&](ArrayRef<int64_t> scaleShape,
+                                      bool isInputScale) {
+      SmallVector<AffineExpr> affineExprs;
+      unsigned outputDim = isInputScale ? 0 : 1;
+      unsigned inputDim = isInputScale ? 0 : 1;
+      for (auto size : scaleShape) {
+        if (size == 1) {
+          affineExprs.push_back(getAffineConstantExpr(0, ctx));
+        } else {
+          while (outputDim < outputShape.size() &&
+                 outputShape[outputDim] != size)
+            outputDim++;
+          affineExprs.push_back(getAffineDimExpr(inputDim, ctx));
+          outputDim++;
+        }
+        inputDim++;
+      }
+      return affineExprs;
+    };
+
+    unsigned rank = outputShapedTy.getRank();
+    auto inScaleShape = cast<ShapedType>(inputScale.getType()).getShape();
+    auto wScaleShape = cast<ShapedType>(weightScale.getType()).getShape();
+    auto oScaleShape = cast<ShapedType>(outputScale.getType()).getShape();
+    maps[1] = AffineMap::get(rank, 0,
+                             createScaleAffineExprs(inScaleShape, true), ctx);
+    maps[2] = AffineMap::get(rank, 0,
+                             createScaleAffineExprs(wScaleShape, false), ctx);
+    maps[3] = AffineMap::get(rank, 0,
+                             createScaleAffineExprs(oScaleShape, false), ctx);
+    iteratorTypes.assign(rank, utils::IteratorType::parallel);
+  }
+
+  Type i8Type = outputShapedTy.getElementType();
+  Type floatTy = builder.getF32Type();
+  // Saturation bounds for signed 8-bit integers.
+  Value lowClamp = arith::ConstantOp::create(
+      builder, loc, builder.getFloatAttr(floatTy, -128.0));
+  Value highClamp = arith::ConstantOp::create(
+      builder, loc, builder.getFloatAttr(floatTy, 127.0));
+
+  auto result =
+      linalg::GenericOp::create(
+          builder, loc, TypeRange{outputShapedTy},
+          ValueRange{chain, inputScale, weightScale, outputScale},
+          ValueRange{output}, maps, iteratorTypes,
+          [&](OpBuilder &nestedBuilder, Location nestedLoc,
+              ValueRange blockArgs) {
+            // Convert the i32 accumulator to float and combine all scales.
+            Value accF = arith::SIToFPOp::create(nestedBuilder, nestedLoc,
+                                                 floatTy, blockArgs[0]);
+            Value inS = createCastToFloat(nestedBuilder, nestedLoc,
+                                          blockArgs[1], floatTy);
+            Value wS = createCastToFloat(nestedBuilder, nestedLoc,
+                                         blockArgs[2], floatTy);
+            Value oS = createCastToFloat(nestedBuilder, nestedLoc,
+                                         blockArgs[3], floatTy);
+            // Dequantize with input/weight scales, then apply output scale.
+            Value scale =
+                arith::MulFOp::create(nestedBuilder, nestedLoc, inS, wS)
+                    ->getResult(0);
+            scale = arith::MulFOp::create(nestedBuilder, nestedLoc, scale, oS)
+                        ->getResult(0);
+            Value scaled =
+                arith::MulFOp::create(nestedBuilder, nestedLoc, accF, scale)
+                    ->getResult(0);
+            // Saturate to the signed i8 range before truncating.
+            scaled = arith::MaximumFOp::create(nestedBuilder, nestedLoc, scaled,
+                                               lowClamp);
+            scaled = arith::MinimumFOp::create(nestedBuilder, nestedLoc, scaled,
+                                               highClamp);
+            Value quantized = arith::FPToSIOp::create(nestedBuilder, nestedLoc,
+                                                      i8Type, scaled);
+            linalg::YieldOp::create(nestedBuilder, nestedLoc,
+                                    ValueRange{quantized});
+          })
+          .getResult(0);
+
+  computeElementwiseScalingFlops(outputShapedTy);
+  return result;
 }
 
 Value MLIRGenerator::dequantizeGemm(LayerArgs &args, Value chain) {
@@ -1238,6 +1418,8 @@ TensorType MLIRGenerator::getShape(ArrayRef<int64_t> dims, PackingType type) {
         return RankedTensorType::get(dims, type == INPUT_SCALE
                                                ? dataTypes.inputScale
                                                : dataTypes.weightScale);
+      } else if (type == OUTPUT_SCALE) {
+        return RankedTensorType::get(dims, dataTypes.outputScale);
       } else if (type == PACK_OUTPUT) {
         return RankedTensorType::get(dims, dataTypes.output);
       } else if (type == PACK_ACCUMULATOR) {
@@ -1303,6 +1485,8 @@ TensorType MLIRGenerator::getShape(ArrayRef<int64_t> dims, PackingType type) {
     return RankedTensorType::get({dims[0]}, dataTypes.inputScale);
   case WEIGHT_SCALE:
     return RankedTensorType::get({dims[0]}, dataTypes.weightScale);
+  case OUTPUT_SCALE:
+    return RankedTensorType::get({dims[0]}, dataTypes.outputScale);
   case PACK_INTERMEDIATE:
     llvm_unreachable("Unknown intermediate packing type");
   }

--- a/tools/mlir-gen/MLIRGen.h
+++ b/tools/mlir-gen/MLIRGen.h
@@ -61,6 +61,7 @@ class MLIRGenerator {
     Type accumulator{};
     Type inputScale{};
     Type weightScale{};
+    Type outputScale{};
   };
   DataTypes dataTypes;
 
@@ -126,8 +127,13 @@ class MLIRGenerator {
     PACK_ACCUMULATOR,
     PACK_INTERMEDIATE,
     INPUT_SCALE,
-    WEIGHT_SCALE
+    WEIGHT_SCALE,
+    OUTPUT_SCALE
   };
+
+  /// Returns true when generating an i8xi8->i32 GEMM that is requantized back
+  /// to i8 (quantize kernel with integer inputs).
+  bool isRequantization() const;
 
   /// Return shaped type (packed if requested)
   TensorType getShape(ArrayRef<int64_t>, PackingType);
@@ -174,6 +180,7 @@ class MLIRGenerator {
     Arg inputScale;
     Arg weight;
     Arg weightScale;
+    Arg outputScale;
     Arg bias;
     Arg intermediate; // For quantdequant validation
     Arg output;
@@ -216,6 +223,10 @@ class MLIRGenerator {
 
   /// Creates a matmul quantization kernel
   Value quantizeGemm(LayerArgs &args, Value chain);
+
+  /// Requantizes an i32 GEMM accumulator back to i8 using a per-output-channel
+  /// output scale argument.
+  Value requantizeGemm(LayerArgs &args, Value chain);
 
   /// Creates a matmul dequantization kernel
   Value dequantizeGemm(LayerArgs &args, Value chain);


### PR DESCRIPTION
[TPP] Stream write-only stores via nontemporal vector.store

    Add a ConvertToStreamingStore pass that rewrites a write-only
    vector.transfer_write (e.g. the GEMM output C matrix, never read back)
    into a vector.store carrying nontemporal = true, avoiding cache pollution
    for data that is not reused. The pass runs after FlattenVectorOps so the
    transfer is already 1-D. Also reposition ReplicateBenchArgs to run on the
    bufferized nano-kernel path.