### PR TITLE
[mlir-gen] Remove redundant empty tensor.

### DIFF
--- a/test/Integration/MLIRGen/mlir-gen-matmul.mlir
+++ b/test/Integration/MLIRGen/mlir-gen-matmul.mlir
@@ -1,5 +1,6 @@
 // RUN: mlir-gen --kernel=args --seed=0 --data-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP32
 // RUN: mlir-gen --kernel=args --seed=0 --data-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=BF16
+// RUN: mlir-gen --kernel=args --data-type=bf16 --batch=8192 --layers=1024,4096 --tiles=32,32,32 --vnni=2 | FileCheck %s --check-prefix=BF16-TRUNCATE
 // RUN: mlir-gen --kernel=args --seed=0 --data-type=f16 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP16
 
 // RUN: mlir-gen --kernel=args --seed=0 --data-type=i8 --batch=128 --layers=2304,768 --tiles=64,48,64 --output=contract 2>&1 | FileCheck %s --check-prefix=I8-CONTRACT
@@ -39,6 +40,12 @@
 // BF16:         arith.mulf
 // BF16:         arith.addf
 // BF16-NOT: dealloc
+
+// Check that tensor.empty() not created to store the result of arith.truncf in the generic op.
+// The result of arith.truncf is directly stored in the output tensor.
+// BF16-TRUNCATE-COUNT-1: tensor.empty() : tensor<256x128x32x32xf32>
+// BF16-TRUNCATE-NOT: tensor.empty() : tensor<256x128x32x32xbf16>
+
 
 // FP16: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // FP16: // RUN{{.*}}-e entry -entry-point-result=void

--- a/tools/mlir-gen/MLIRGen.cpp
+++ b/tools/mlir-gen/MLIRGen.cpp
@@ -117,7 +117,8 @@ static Value createCastToFloat(OpBuilder &builder, Location loc, Value value,
 // linalg.generic using arith.truncf/arith.trunci. Cross-domain conversions
 // (e.g. quantization/dequantization) are handled by their dedicated lowerings.
 static Value downcastToOutput(OpBuilder &builder, Location loc,
-                              Value accumulator, ShapedType outputType) {
+                              Value accumulator, Value output,
+                              ShapedType outputType) {
   auto accTy = cast<ShapedType>(accumulator.getType());
   Type accElem = accTy.getElementType();
   Type outElem = outputType.getElementType();
@@ -130,14 +131,13 @@ static Value downcastToOutput(OpBuilder &builder, Location loc,
   // we have returned above. If not, then we need to allocate a new buffer, since they
   // have different types. This will be the `chain` to the next operation.
   auto resultTy = RankedTensorType::get(accTy.getShape(), outElem);
-  Value dest = tensor::EmptyOp::create(builder, loc, resultTy, ValueRange{});
   int64_t rank = accTy.getRank();
   SmallVector<AffineMap> maps(2, builder.getMultiDimIdentityMap(rank));
   SmallVector<utils::IteratorType> iterators(rank,
                                              utils::IteratorType::parallel);
   return linalg::GenericOp::create(
-             builder, loc, resultTy, ValueRange{accumulator}, ValueRange{dest},
-             maps, iterators,
+             builder, loc, resultTy, ValueRange{accumulator},
+             ValueRange{output}, maps, iterators,
              [&](OpBuilder &nestedBuilder, Location nestedLoc,
                  ValueRange blockArgs) {
                Value trunc;
@@ -617,7 +617,8 @@ Value MLIRGenerator::lowerMatmul(LayerArgs &args) {
     return dequantizeGemm(args, accumulator);
   }
 
-  return downcastToOutput(builder, loc, accumulator, args.output.type);
+  return downcastToOutput(builder, loc, accumulator, args.output.value,
+                          args.output.type);
 }
 
 Value MLIRGenerator::lowerGenericMatmul(LayerArgs &args, Value chain) {


### PR DESCRIPTION
Currently truncated result is being written into a new tensor instead of output argument. This patch fixes it.