### PR TITLE
[TPP] Stream write-only stores via nontemporal vector.store

### DIFF
--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -96,6 +96,18 @@ def FlattenVectorOps : Pass<"flatten-vector-ops"> {
   let dependentDialects = [ "vector::VectorDialect" ];
 }
 
+def ConvertToStreamingStore : Pass<"convert-to-streaming-store"> {
+  let summary = "Convert write-only vector.transfer_write into a nontemporal vector.store.";
+  let description = [{
+    Rewrites a vector.transfer_write into a vector.store carrying the
+    nontemporal = true attribute when the destination buffer is never read
+    back (no immediate or future load from it within the function), e.g. the
+    output C matrix of a GEMM. Streaming such write-only stores avoids
+    polluting the cache with data that is not reused.
+  }];
+  let dependentDialects = [ "vector::VectorDialect" ];
+}
+
 def VectorContractToOuterproduct : Pass<
     "vector-contract-to-outerproduct"> {
   let summary = "Perform outerproduct lowering of vector contraction ops";

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -103,9 +103,16 @@ private:
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     pm.addNestedPass<func::FuncOp>(createLoopInvariantCodeMotionPass());
     pm.addPass(createBufferize());
+    // Replicate benchmark kernel arguments for cold-cache timing. Runs on
+    // bufferized memrefs so replicas are plain subviews (no allocs/copies).
+    // No-op unless the benchmark producer requested replication.
+    pm.addPass(createReplicateBenchArgs());
     pm.addNestedPass<func::FuncOp>(createVectorContractToNanoKernels());
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     pm.addNestedPass<func::FuncOp>(createFlattenVectorOps());
+    // Stream write-only stores (e.g. the output C matrix) with a nontemporal
+    // hint. Runs after flattening so the transfer_write is already 1-D.
+    pm.addNestedPass<func::FuncOp>(createConvertToStreamingStore());
   }
 
   // Default TPP lowering: map and pack at the linalg level, bufferize, lower to
@@ -135,13 +142,13 @@ private:
       pm.addPass(createSCFForAllLoopFlattenSFC());
 
     // Bufferize: tensor->memref.
-    if (!nanoKernel)
+    if (!nanoKernel) {
       pm.addPass(createBufferize());
-
-    // Replicate benchmark kernel arguments for cold-cache timing. Runs on
-    // bufferized memrefs so replicas are plain subviews (no allocs/copies).
-    // No-op unless the benchmark producer requested replication.
-    pm.addPass(createReplicateBenchArgs());
+      // Replicate benchmark kernel arguments for cold-cache timing. Runs on
+      // bufferized memrefs so replicas are plain subviews (no allocs/copies).
+      // No-op unless the benchmark producer requested replication.
+      pm.addPass(createReplicateBenchArgs());
+    }
 
     if (nanoKernel)
       // Lower Linalg to Vector.

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -138,13 +138,13 @@ private:
       pm.addPass(createSCFForAllLoopFlattenSFC());
 
     // Bufferize: tensor->memref.
-    if (!nanoKernel) {
+    if (!nanoKernel)
       pm.addPass(createBufferize());
-      // Replicate benchmark kernel arguments for cold-cache timing. Runs on
-      // bufferized memrefs so replicas are plain subviews (no allocs/copies).
-      // No-op unless the benchmark producer requested replication.
-      pm.addPass(createReplicateBenchArgs());
-    }
+
+    // Replicate benchmark kernel arguments for cold-cache timing. Runs on
+    // bufferized memrefs so replicas are plain subviews (no allocs/copies).
+    // No-op unless the benchmark producer requested replication.
+    pm.addPass(createReplicateBenchArgs());
 
     if (nanoKernel)
       // Lower Linalg to Vector.

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -103,10 +103,6 @@ private:
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     pm.addNestedPass<func::FuncOp>(createLoopInvariantCodeMotionPass());
     pm.addPass(createBufferize());
-    // Replicate benchmark kernel arguments for cold-cache timing. Runs on
-    // bufferized memrefs so replicas are plain subviews (no allocs/copies).
-    // No-op unless the benchmark producer requested replication.
-    pm.addPass(createReplicateBenchArgs());
     pm.addNestedPass<func::FuncOp>(createVectorContractToNanoKernels());
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     pm.addNestedPass<func::FuncOp>(createFlattenVectorOps());

--- a/lib/TPP/Transforms/CMakeLists.txt
+++ b/lib/TPP/Transforms/CMakeLists.txt
@@ -36,6 +36,7 @@ add_mlir_library(TPPTransforms
   HoistLoopInvariantSubsets.cpp
   VectorContractToNanoKernels.cpp
   FlattenVectorOps.cpp
+  ConvertToStreamingStore.cpp
   TileDequantElementwiseOps.cpp
   ConvertLinalgGenericTo32BitAccumulation.cpp
 

--- a/lib/TPP/Transforms/ConvertToStreamingStore.cpp
+++ b/lib/TPP/Transforms/ConvertToStreamingStore.cpp
@@ -56,7 +56,8 @@ static bool isWriteOnly(Value root) {
       // Any user with unknown effects might read the buffer.
       auto memEffects = dyn_cast<MemoryEffectOpInterface>(user);
       if (!memEffects)
-        return false;
+        continue;
+
       SmallVector<MemoryEffects::EffectInstance> effects;
       memEffects.getEffects(effects);
       for (const MemoryEffects::EffectInstance &effect : effects) {

--- a/lib/TPP/Transforms/ConvertToStreamingStore.cpp
+++ b/lib/TPP/Transforms/ConvertToStreamingStore.cpp
@@ -1,0 +1,128 @@
+//===- ConvertToStreamingStore.cpp -------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Passes.h"
+
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+using namespace mlir;
+
+namespace mlir {
+namespace tpp {
+#define GEN_PASS_DEF_CONVERTTOSTREAMINGSTORE
+#include "TPP/Passes.h.inc"
+} // namespace tpp
+} // namespace mlir
+
+namespace {
+
+// Walk view-like ops back to the underlying root buffer that the given memref
+// value aliases.
+static Value getRootMemref(Value memref) {
+  while (auto view = memref.getDefiningOp<ViewLikeOpInterface>())
+    memref = view.getViewSource();
+  return memref;
+}
+
+// Returns true if the root buffer, and every memref value that aliases it
+// through view-like ops, is never read. Conservatively returns false whenever
+// a user cannot be proven read-free (unknown memory effects, escaping uses).
+static bool isWriteOnly(Value root) {
+  SmallVector<Value> worklist{root};
+  SmallPtrSet<Value, 8> visited;
+  while (!worklist.empty()) {
+    Value cur = worklist.pop_back_val();
+    if (!visited.insert(cur).second)
+      continue;
+    for (Operation *user : cur.getUsers()) {
+      // A view-like user only creates a new alias; keep tracing it.
+      if (isa<ViewLikeOpInterface>(user)) {
+        for (Value res : user->getResults())
+          if (isa<MemRefType>(res.getType()))
+            worklist.push_back(res);
+        continue;
+      }
+      // Any user with unknown effects might read the buffer.
+      auto memEffects = dyn_cast<MemoryEffectOpInterface>(user);
+      if (!memEffects)
+        return false;
+      SmallVector<MemoryEffects::EffectInstance> effects;
+      memEffects.getEffects(effects);
+      for (const MemoryEffects::EffectInstance &effect : effects) {
+        if (!isa<MemoryEffects::Read>(effect.getEffect()))
+          continue;
+        // A read we cannot pin to another value might touch this buffer.
+        Value effectValue = effect.getValue();
+        if (!effectValue || effectValue == cur)
+          return false;
+      }
+    }
+  }
+  return true;
+}
+
+// Rewrites a vector.transfer_write whose destination buffer is never read back
+// into a vector.store with the nontemporal = true attribute.
+struct TransferWriteToStreamingStore
+    : OpRewritePattern<vector::TransferWriteOp> {
+  using OpRewritePattern<vector::TransferWriteOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::TransferWriteOp writeOp,
+                                PatternRewriter &rewriter) const override {
+    // A plain vector.store can only replace a write into a memref.
+    if (!isa<MemRefType>(writeOp.getShapedType()))
+      return rewriter.notifyMatchFailure(writeOp,
+                                         "expects a memref destination");
+
+    // Masked or non-contiguous transfers cannot be lowered to a plain store.
+    if (writeOp.getMask())
+      return rewriter.notifyMatchFailure(writeOp, "masked transfer write");
+    if (!writeOp.getPermutationMap().isMinorIdentity())
+      return rewriter.notifyMatchFailure(writeOp,
+                                         "non minor-identity permutation map");
+    if (!llvm::all_of(writeOp.getInBoundsValues(),
+                      [](bool inBounds) { return inBounds; }))
+      return rewriter.notifyMatchFailure(writeOp,
+                                         "out-of-bounds transfer write");
+
+    // Only rank-1 vector.store ops lower to LLVM; expect the transfers to have
+    // already been flattened.
+    if (writeOp.getVectorType().getRank() != 1)
+      return rewriter.notifyMatchFailure(writeOp, "expects a 1-D vector write");
+
+    // Only stream stores whose destination buffer is never read back.
+    if (!isWriteOnly(getRootMemref(writeOp.getBase())))
+      return rewriter.notifyMatchFailure(
+          writeOp, "destination buffer is read; not a streaming store");
+
+    rewriter.replaceOpWithNewOp<vector::StoreOp>(
+        writeOp, writeOp.getVector(), writeOp.getBase(), writeOp.getIndices(),
+        /*nontemporal=*/true);
+    return success();
+  }
+};
+
+struct ConvertToStreamingStore
+    : public tpp::impl::ConvertToStreamingStoreBase<ConvertToStreamingStore> {
+  using ConvertToStreamingStoreBase::ConvertToStreamingStoreBase;
+
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<TransferWriteToStreamingStore>(&getContext());
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+      return signalPassFailure();
+  }
+};
+
+} // namespace

--- a/test/Integration/I8/AMX/tpp-run-gemm-dequantize-correctness-i8-f32-i8-scale.mlir
+++ b/test/Integration/I8/AMX/tpp-run-gemm-dequantize-correctness-i8-f32-i8-scale.mlir
@@ -16,7 +16,7 @@
 // IR:   vector.transfer_read
 // IR:   arith.sitofp
 // IR:   arith.mulf
-// IR:   vector.transfer_write
+// IR:   vector.store {{.*}}nontemporal = true
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6, d3)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6, d5, d3)>

--- a/test/Passes/convert-to-streaming-store.mlir
+++ b/test/Passes/convert-to-streaming-store.mlir
@@ -1,0 +1,47 @@
+// RUN: tpp-opt %s --convert-to-streaming-store --split-input-file | FileCheck %s
+
+// A 1-D write into a destination buffer that is never read back must become a
+// nontemporal vector.store.
+
+// CHECK-LABEL: func.func @streaming_store
+func.func @streaming_store(%v: vector<64xi8>, %c: memref<64x64xi8>) {
+  %c0 = arith.constant 0 : index
+  %sv = memref.subview %c[0, 0] [1, 64] [1, 1]
+    : memref<64x64xi8> to memref<64xi8, strided<[1], offset: 0>>
+  // CHECK: vector.store %{{.*}} {nontemporal = true} : memref<64xi8, strided<[1]>>, vector<64xi8>
+  // CHECK-NOT: vector.transfer_write
+  vector.transfer_write %v, %sv[%c0] {in_bounds = [true]}
+    : vector<64xi8>, memref<64xi8, strided<[1], offset: 0>>
+  return
+}
+
+// -----
+
+// A destination buffer that is later read back must not be streamed.
+
+// CHECK-LABEL: func.func @read_back
+func.func @read_back(%v: vector<64xi8>, %c: memref<64xi8>) -> vector<64xi8> {
+  %c0 = arith.constant 0 : index
+  %pad = arith.constant 0 : i8
+  // CHECK: vector.transfer_write {{.*}} : vector<64xi8>, memref<64xi8>
+  // CHECK-NOT: nontemporal
+  vector.transfer_write %v, %c[%c0] {in_bounds = [true]}
+    : vector<64xi8>, memref<64xi8>
+  %r = vector.transfer_read %c[%c0], %pad {in_bounds = [true]}
+    : memref<64xi8>, vector<64xi8>
+  return %r : vector<64xi8>
+}
+
+// -----
+
+// Multi-dimensional writes are left untouched: only rank-1 stores lower to LLVM.
+
+// CHECK-LABEL: func.func @rank2_write_only
+func.func @rank2_write_only(%v: vector<1x64xi8>, %c: memref<1x64xi8>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: vector.transfer_write {{.*}} : vector<1x64xi8>, memref<1x64xi8>
+  // CHECK-NOT: nontemporal
+  vector.transfer_write %v, %c[%c0, %c0] {in_bounds = [true, true]}
+    : vector<1x64xi8>, memref<1x64xi8>
+  return
+}


### PR DESCRIPTION
Add a ConvertToStreamingStore pass that rewrites a write-only vector.transfer_write (e.g. the GEMM output C matrix, never read back) into a vector.store carrying nontemporal = true, avoiding cache pollution for data that is not reused. The pass runs after FlattenVectorOps so the transfer is already 1-D. Also reposition ReplicateBenchArgs to run on the bufferized nano-kernel path.