### PR TITLE
[ReplicateBenchArgs] Fix crash on value-returning kernels

### DIFF
--- a/lib/TPP/Transforms/ReplicateBenchArgs.cpp
+++ b/lib/TPP/Transforms/ReplicateBenchArgs.cpp
@@ -292,7 +292,23 @@ struct ReplicateBenchArgs
               /*sizes=*/ValueRange{});
         }
 
-        func::CallOp::create(bodyBuilder, loc, kernel, viewArgs);
+        auto newCall = func::CallOp::create(bodyBuilder, loc, kernel, viewArgs);
+
+        // When the kernel returns results (e.g. an internally-allocated output
+        // buffer), the original call is consumed by trailing cleanup ops
+        // (extract_strided_metadata/dealloc) in the bench body. Rewire those
+        // uses to the replicated call.
+        call.replaceAllUsesWith(newCall);
+        if (call->getNumResults() != 0) {
+          Operation *benchTerminator = call->getBlock()->getTerminator();
+          Operation *loopTerminator = loop.getBody()->getTerminator();
+          SmallVector<Operation *> cleanup;
+          for (Operation *op = call->getNextNode(); op && op != benchTerminator;
+               op = op->getNextNode())
+            cleanup.push_back(op);
+          for (Operation *op : cleanup)
+            op->moveBefore(loopTerminator);
+        }
         call.erase();
       }
     }

--- a/lib/TPP/Transforms/ReplicateBenchArgs.cpp
+++ b/lib/TPP/Transforms/ReplicateBenchArgs.cpp
@@ -43,6 +43,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 
 using namespace mlir;
@@ -296,16 +297,49 @@ struct ReplicateBenchArgs
 
         // When the kernel returns results (e.g. an internally-allocated output
         // buffer), the original call is consumed by trailing cleanup ops
-        // (extract_strided_metadata/dealloc) in the bench body. Rewire those
-        // uses to the replicated call.
-        call.replaceAllUsesWith(newCall);
+        // (extract_strided_metadata/dealloc) in the bench body. Those must be
+        // rewired to the replicated call and sunk into the loop so each
+        // replica's buffer is freed once per iteration.
         if (call->getNumResults() != 0) {
           Operation *benchTerminator = call->getBlock()->getTerminator();
           Operation *loopTerminator = loop.getBody()->getTerminator();
+
+          // Collect the ops trailing the call up to the bench terminator.
           SmallVector<Operation *> cleanup;
           for (Operation *op = call->getNextNode(); op && op != benchTerminator;
                op = op->getNextNode())
             cleanup.push_back(op);
+
+          // Each trailing op must be a known cleanup op that transitively
+          // consumes the call result, i.e. the trailing range is exactly the
+          // result's forward slice.
+          llvm::SmallPtrSet<Operation *, 4> derived;
+          for (Operation *op : cleanup) {
+            bool consumesResult = llvm::any_of(op->getOperands(), [&](Value v) {
+              Operation *def = v.getDefiningOp();
+              return def == call.getOperation() ||
+                     (def && derived.contains(def));
+            });
+            if (!consumesResult ||
+                !isa<memref::ExtractStridedMetadataOp, memref::DeallocOp>(op)) {
+              call.emitError("Only extract_strided_metadata/dealloc cleanup of "
+                             "the result can be replicated");
+              return signalPassFailure();
+            }
+            derived.insert(op);
+          }
+
+          // No use of the call result may escape that cleanup set, otherwise
+          // sinking it into the loop would leave a dangling reference.
+          for (Operation *user : call->getUsers()) {
+            if (!derived.contains(user)) {
+              call.emitError("Kernel result escapes the bench cleanup; cannot "
+                             "replicate safely");
+              return signalPassFailure();
+            }
+          }
+
+          call.replaceAllUsesWith(newCall);
           for (Operation *op : cleanup)
             op->moveBefore(loopTerminator);
         }

--- a/test/Passes/replicate-bench-args.mlir
+++ b/test/Passes/replicate-bench-args.mlir
@@ -77,3 +77,36 @@ module {
     return %stat : f64
   }
 }
+
+// -----
+
+// A value-returning kernel (internally-allocated output) is consumed by
+// extract_strided_metadata/dealloc cleanup ops inside the bench body. The pass
+// must rewire those uses to the replicated call.
+
+// CHECK: memref.global "private" @__bench_replica_0
+// CHECK: memref.global "private" @__bench_replica_1
+// CHECK-LABEL: func.func @entry
+// CHECK: perf.bench
+// CHECK:   scf.for
+// CHECK:     %[[RES:.+]] = func.call @kernel(%{{.+}}, %{{.+}}) : {{.*}} -> memref<4x4xf32>
+// CHECK:     %[[BASE:.+]], %{{.+}}, %{{.+}}:2, %{{.+}}:2 = memref.extract_strided_metadata %[[RES]]
+// CHECK:     memref.dealloc %[[BASE]]
+// CHECK-NOT: func.call @kernel
+module attributes {tpp.bench_replication_factor = 4 : i64} {
+  func.func @kernel(%A: memref<4x8xf32>, %B: memref<8x4xf32>) -> memref<4x4xf32> {
+    %C = memref.alloc() : memref<4x4xf32>
+    linalg.matmul ins(%A, %B : memref<4x8xf32>, memref<8x4xf32>) outs(%C : memref<4x4xf32>)
+    return %C : memref<4x4xf32>
+  }
+  func.func @entry(%A: memref<4x8xf32>, %B: memref<8x4xf32>, %n: i64) -> f64 {
+    %stat = perf.bench (%n : i64) -> f64 {
+      %C = func.call @kernel(%A, %B) : (memref<4x8xf32>, memref<8x4xf32>) -> memref<4x4xf32>
+      %base, %off, %sizes:2, %strides:2 = memref.extract_strided_metadata %C
+        : memref<4x4xf32> -> memref<f32>, index, index, index, index, index
+      memref.dealloc %base : memref<f32>
+      perf.yield
+    }
+    return %stat : f64
+  }
+}


### PR DESCRIPTION
The pass erased the original kernel call unconditionally, but for kernels that return a result (e.g. an internally-allocated output buffer) the call was still consumed by trailing cleanup ops (extract_strided_metadata/dealloc) in the bench body, triggering 'operation destroyed but still has uses'.Rewire those uses to the replicated call.