### PR TITLE
Allow tiling of single-op elementwise linalg.generic body.

### DIFF
--- a/lib/TPP/Transforms/TileConsumerAndFuseProducers.cpp
+++ b/lib/TPP/Transforms/TileConsumerAndFuseProducers.cpp
@@ -824,13 +824,6 @@ struct TileElementWiseOps
           return rewriter.notifyMatchFailure(
               op, "Only tiles linalg.generic with elementwise semantics");
 
-        // Exit if no non-terminating operations in the body (e.g., just a
-        // yield)
-        Block &body = op.getRegion().front();
-        if (body.without_terminator().empty())
-          return rewriter.notifyMatchFailure(
-              op, "No non-terminating operations in the body");
-
         // Exit for Op without inputs.
         if (op.getDpsInputs().empty())
           return rewriter.notifyMatchFailure(op,

--- a/lib/TPP/Transforms/TileConsumerAndFuseProducers.cpp
+++ b/lib/TPP/Transforms/TileConsumerAndFuseProducers.cpp
@@ -831,11 +831,6 @@ struct TileElementWiseOps
           return rewriter.notifyMatchFailure(
               op, "No non-terminating operations in the body");
 
-        auto bodyOps = body.without_terminator();
-        if (llvm::hasSingleElement(bodyOps))
-          return rewriter.notifyMatchFailure(
-              op, "Dont tile linalg.generic with single op in the body.");
-
         // Exit for Op without inputs.
         if (op.getDpsInputs().empty())
           return rewriter.notifyMatchFailure(op,

--- a/test/Passes/tile-elementwise-ops.mlir
+++ b/test/Passes/tile-elementwise-ops.mlir
@@ -41,12 +41,13 @@ func.func @tile_basic_elementwise(%arg0: tensor<32x64xf32>,
 
 // -----
 
-// Test 2: Single-op body (e.g., just yield of an arg) should NOT be tiled.
+// Test 2: Copy body (just a yield of an input) is tiled so it can fuse with
+// surrounding tiled ops.
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @no_tile_single_op_body(%arg0: tensor<32x64xf32>,
-                                   %arg1: tensor<32x64xf32>) -> tensor<32x64xf32> {
+func.func @tile_copy_body(%arg0: tensor<32x64xf32>,
+                          %arg1: tensor<32x64xf32>) -> tensor<32x64xf32> {
   %0 = linalg.generic {
     indexing_maps = [#map, #map],
     iterator_types = ["parallel", "parallel"]
@@ -58,10 +59,16 @@ func.func @no_tile_single_op_body(%arg0: tensor<32x64xf32>,
   return %0 : tensor<32x64xf32>
 }
 
-// CHECK-LABEL: func.func @no_tile_single_op_body
-// CHECK-NOT:     scf.for
-// CHECK:         linalg.generic
-// CHECK-SAME:      ins({{.*}} : tensor<32x64xf32>) outs({{.*}} : tensor<32x64xf32>)
+// CHECK-LABEL: func.func @tile_copy_body
+// CHECK:         scf.for
+// CHECK:           linalg.generic
+// CHECK-SAME:        ins({{.*}} : tensor<1x64xf32>) outs({{.*}} : tensor<1x64xf32>)
+
+// CUSTOM-LABEL: func.func @tile_copy_body
+// CUSTOM:         scf.for %{{.*}} step %c4
+// CUSTOM:           scf.for %{{.*}} step %c8
+// CUSTOM:             linalg.generic
+// CUSTOM-SAME:          ins({{.*}} : tensor<4x8xf32>) outs({{.*}} : tensor<4x8xf32>)
 
 // -----
 
@@ -88,6 +95,13 @@ func.func @tile_single_op(%arg0: tensor<32x64xf32>,
 // CHECK:         linalg.generic
 // CHECK-SAME:      ins({{.*}} : tensor<1x64xf32>)
 // CHECK:           arith.truncf
+
+// CUSTOM-LABEL: func.func @tile_single_op
+// CUSTOM:         scf.for %{{.*}} step %c4
+// CUSTOM:           scf.for %{{.*}} step %c8
+// CUSTOM:             linalg.generic
+// CUSTOM-SAME:          ins({{.*}} : tensor<4x8xf32>)
+// CUSTOM:               arith.truncf
 
 // -----
 
@@ -117,6 +131,10 @@ func.func @no_tile_reduction(%arg0: tensor<32x64xf32>,
 // CHECK-NOT:     scf.for
 // CHECK:         linalg.generic {{.*}}iterator_types = ["parallel", "parallel", "reduction"]
 
+// CUSTOM-LABEL: func.func @no_tile_reduction
+// CUSTOM-NOT:     scf.for
+// CUSTOM:         linalg.generic {{.*}}iterator_types = ["parallel", "parallel", "reduction"]
+
 // -----
 
 // Test 4: Op without inputs should NOT be tiled.
@@ -138,6 +156,10 @@ func.func @no_tile_no_inputs(%arg0: tensor<32x64xf32>) -> tensor<32x64xf32> {
 // CHECK-LABEL: func.func @no_tile_no_inputs
 // CHECK-NOT:     scf.for
 // CHECK:         linalg.generic
+
+// CUSTOM-LABEL: func.func @no_tile_no_inputs
+// CUSTOM-NOT:     scf.for
+// CUSTOM:         linalg.generic
 
 // -----
 
@@ -162,6 +184,10 @@ func.func @no_tile_3d(%arg0: tensor<4x32x64xf32>,
 // CHECK-LABEL: func.func @no_tile_3d
 // CHECK-NOT:     scf.for
 // CHECK:         linalg.generic {{.*}}iterator_types = ["parallel", "parallel", "parallel"]
+
+// CUSTOM-LABEL: func.func @no_tile_3d
+// CUSTOM-NOT:     scf.for
+// CUSTOM:         linalg.generic {{.*}}iterator_types = ["parallel", "parallel", "parallel"]
 
 // -----
 

--- a/test/Passes/tile-elementwise-ops.mlir
+++ b/test/Passes/tile-elementwise-ops.mlir
@@ -1,0 +1,206 @@
+// RUN: tpp-opt %s -tile-elementwise-ops -split-input-file | FileCheck %s
+// RUN: tpp-opt %s -tile-elementwise-ops="tile-sizes=4,8" -split-input-file | FileCheck %s --check-prefix=CUSTOM
+
+// -----
+// Test 1: Basic 2D elementwise op gets tiled with default sizes [1, N]
+// where N is the inner dimension of the output shape.
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @tile_basic_elementwise(%arg0: tensor<32x64xf32>,
+                                   %arg1: tensor<32x64xf32>,
+                                   %arg2: tensor<32x64xf32>) -> tensor<32x64xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map, #map, #map],
+    iterator_types = ["parallel", "parallel"]
+  } ins(%arg0, %arg1 : tensor<32x64xf32>, tensor<32x64xf32>)
+    outs(%arg2 : tensor<32x64xf32>) {
+  ^bb0(%a: f32, %b: f32, %c: f32):
+    %m = arith.mulf %a, %b : f32
+    %r = arith.addf %m, %c : f32
+    linalg.yield %r : f32
+  } -> tensor<32x64xf32>
+  return %0 : tensor<32x64xf32>
+}
+
+// CHECK-LABEL: func.func @tile_basic_elementwise
+// CHECK:         scf.for %{{.*}} = %c0 to %c32 step %c1
+// CHECK:           tensor.extract_slice {{.*}} [1, 64]
+// CHECK:           linalg.generic
+// CHECK-SAME:        ins({{.*}} : tensor<1x64xf32>, tensor<1x64xf32>)
+// CHECK-SAME:        outs({{.*}} : tensor<1x64xf32>)
+// CHECK:             arith.mulf
+// CHECK:             arith.addf
+// CHECK:           tensor.insert_slice
+
+// CUSTOM-LABEL: func.func @tile_basic_elementwise
+// CUSTOM:         scf.for %{{.*}} step %c4
+// CUSTOM:           scf.for %{{.*}} step %c8
+// CUSTOM:             linalg.generic
+// CUSTOM-SAME:          ins({{.*}} : tensor<4x8xf32>, tensor<4x8xf32>)
+
+// -----
+
+// Test 2: Single-op body (e.g., just yield of an arg) should NOT be tiled.
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @no_tile_single_op_body(%arg0: tensor<32x64xf32>,
+                                   %arg1: tensor<32x64xf32>) -> tensor<32x64xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map, #map],
+    iterator_types = ["parallel", "parallel"]
+  } ins(%arg0 : tensor<32x64xf32>)
+    outs(%arg1 : tensor<32x64xf32>) {
+  ^bb0(%a: f32, %c: f32):
+    linalg.yield %a : f32
+  } -> tensor<32x64xf32>
+  return %0 : tensor<32x64xf32>
+}
+
+// CHECK-LABEL: func.func @no_tile_single_op_body
+// CHECK-NOT:     scf.for
+// CHECK:         linalg.generic
+// CHECK-SAME:      ins({{.*}} : tensor<32x64xf32>) outs({{.*}} : tensor<32x64xf32>)
+
+// -----
+
+// Single non-terminating op body (e.g., a lone arith.truncf) is tiled.
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @tile_single_op(%arg0: tensor<32x64xf32>,
+                                 %arg1: tensor<32x64xbf16>) -> tensor<32x64xbf16> {
+  %0 = linalg.generic {
+    indexing_maps = [#map, #map],
+    iterator_types = ["parallel", "parallel"]
+  } ins(%arg0 : tensor<32x64xf32>)
+    outs(%arg1 : tensor<32x64xbf16>) {
+  ^bb0(%a: f32, %c: bf16):
+    %t = arith.truncf %a : f32 to bf16
+    linalg.yield %t : bf16
+  } -> tensor<32x64xbf16>
+  return %0 : tensor<32x64xbf16>
+}
+
+// CHECK-LABEL: func.func @tile_single_op
+// CHECK:        scf.for
+// CHECK:         linalg.generic
+// CHECK-SAME:      ins({{.*}} : tensor<1x64xf32>)
+// CHECK:           arith.truncf
+
+// -----
+
+// Test 3: Op with reduction iterator should NOT be tiled (not elementwise).
+
+#mapA = affine_map<(d0, d1, d2) -> (d0, d2)>
+#mapB = affine_map<(d0, d1, d2) -> (d2, d1)>
+#mapC = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+func.func @no_tile_reduction(%arg0: tensor<32x64xf32>,
+                              %arg1: tensor<64x16xf32>,
+                              %arg2: tensor<32x16xf32>) -> tensor<32x16xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#mapA, #mapB, #mapC],
+    iterator_types = ["parallel", "parallel", "reduction"]
+  } ins(%arg0, %arg1 : tensor<32x64xf32>, tensor<64x16xf32>)
+    outs(%arg2 : tensor<32x16xf32>) {
+  ^bb0(%a: f32, %b: f32, %c: f32):
+    %m = arith.mulf %a, %b : f32
+    %r = arith.addf %m, %c : f32
+    linalg.yield %r : f32
+  } -> tensor<32x16xf32>
+  return %0 : tensor<32x16xf32>
+}
+
+// CHECK-LABEL: func.func @no_tile_reduction
+// CHECK-NOT:     scf.for
+// CHECK:         linalg.generic {{.*}}iterator_types = ["parallel", "parallel", "reduction"]
+
+// -----
+
+// Test 4: Op without inputs should NOT be tiled.
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @no_tile_no_inputs(%arg0: tensor<32x64xf32>) -> tensor<32x64xf32> {
+  %cst = arith.constant 1.0 : f32
+  %0 = linalg.generic {
+    indexing_maps = [#map],
+    iterator_types = ["parallel", "parallel"]
+  } outs(%arg0 : tensor<32x64xf32>) {
+  ^bb0(%c: f32):
+    linalg.yield %cst : f32
+  } -> tensor<32x64xf32>
+  return %0 : tensor<32x64xf32>
+}
+
+// CHECK-LABEL: func.func @no_tile_no_inputs
+// CHECK-NOT:     scf.for
+// CHECK:         linalg.generic
+
+// -----
+
+// Test 5: 3D elementwise op should NOT be tiled (rank != 2).
+
+#map3d = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+
+func.func @no_tile_3d(%arg0: tensor<4x32x64xf32>,
+                       %arg1: tensor<4x32x64xf32>) -> tensor<4x32x64xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map3d, #map3d],
+    iterator_types = ["parallel", "parallel", "parallel"]
+  } ins(%arg0 : tensor<4x32x64xf32>)
+    outs(%arg1 : tensor<4x32x64xf32>) {
+  ^bb0(%a: f32, %c: f32):
+    %r = math.exp %a : f32
+    linalg.yield %r : f32
+  } -> tensor<4x32x64xf32>
+  return %0 : tensor<4x32x64xf32>
+}
+
+// CHECK-LABEL: func.func @no_tile_3d
+// CHECK-NOT:     scf.for
+// CHECK:         linalg.generic {{.*}}iterator_types = ["parallel", "parallel", "parallel"]
+
+// -----
+
+// Test 6: Dequantization-like elementwise pattern (multi-op body) should be tiled.
+// Mimics the i8 dequant pattern: combined_scale * sitofp(dot)
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#mapR = affine_map<(d0, d1) -> (d0)>
+#mapC = affine_map<(d0, d1) -> (d1)>
+
+func.func @tile_dequant_eltwise(%dot: tensor<128x768xi32>,
+                                 %iScale: tensor<128xf32>,
+                                 %wScale: tensor<768xf32>,
+                                 %out: tensor<128x768xf32>) -> tensor<128x768xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map, #mapR, #mapC, #map],
+    iterator_types = ["parallel", "parallel"]
+  } ins(%dot, %iScale, %wScale
+        : tensor<128x768xi32>, tensor<128xf32>, tensor<768xf32>)
+    outs(%out : tensor<128x768xf32>) {
+  ^bb0(%d: i32, %is: f32, %ws: f32, %o: f32):
+    %c = arith.mulf %is, %ws : f32
+    %f = arith.sitofp %d : i32 to f32
+    %r = arith.mulf %f, %c : f32
+    linalg.yield %r : f32
+  } -> tensor<128x768xf32>
+  return %0 : tensor<128x768xf32>
+}
+
+// CHECK-LABEL: func.func @tile_dequant_eltwise
+// CHECK:         scf.for %{{.*}} = %c0 to %c128 step %c1
+// CHECK:           linalg.generic
+// CHECK-SAME:        outs({{.*}} : tensor<1x768xf32>)
+// CHECK:             arith.mulf
+// CHECK:             arith.sitofp
+// CHECK:             arith.mulf
+
+// CUSTOM-LABEL: func.func @tile_dequant_eltwise
+// CUSTOM:         scf.for %{{.*}} step %c4
+// CUSTOM:           scf.for %{{.*}} step %c8
+// CUSTOM:             linalg.generic
+// CUSTOM-SAME:          outs({{.*}} : tensor<4x8xf32>)


### PR DESCRIPTION
 Earlier single op tling was not allowed conservatively. This causes
 sub-optimal code generation while writing the final output.This patch
 removes this restriction.