### PR TITLE
Lighthouse Import MLP generator

### DIFF
--- a/test/Ingress/Inputs/linear.py
+++ b/test/Ingress/Inputs/linear.py
@@ -1,0 +1,36 @@
+import torch
+import torch.nn as nn
+
+M = 64
+N = 64
+K = 64
+
+class Model(nn.Module):
+    def __init__(self, M=M, N=N, K=K, bias=False, layers=1, relu=False, rand=False, trans_a=False, trans_b=False):
+        super().__init__()
+        self.layers = layers
+        self.relu = relu
+        self.trans = trans_a
+        self.fc = nn.Linear(K, N, bias=bias)
+        if not rand:
+          with torch.no_grad():
+              self.fc.weight.fill_(1.0)
+              if bias:
+                  self.fc.bias.fill_(0.0)
+        if trans_b:
+            self.fc.weight = nn.Parameter(torch.transpose(self.fc.weight, 0, 1))
+
+    def forward(self, x):
+        for _ in range(self.layers):
+            if self.trans:
+                x = torch.transpose(x, 0, 1)
+            x = self.fc(x)
+            if self.relu:
+                x = torch.relu(x)
+        return x
+
+def get_init_inputs():
+    return [M, N, K, False, 1, False, False, False, False]
+
+def get_inputs():
+    return (torch.ones(M, K),)

--- a/test/Ingress/linear.mlir
+++ b/test/Ingress/linear.mlir
@@ -1,0 +1,49 @@
+// RUN: torch-import %S/Inputs/linear.py --splat | FileCheck %s --check-prefix=SINGLE_GEMM
+// RUN: torch-import %S/Inputs/linear.py --splat --layers=2 | FileCheck %s --check-prefix=DOUBLE_GEMM
+// RUN: torch-import %S/Inputs/linear.py --splat --bias --relu | FileCheck %s --check-prefix=MLP
+// RUN: torch-import %S/Inputs/linear.py --splat --trans_a | FileCheck %s --check-prefix=TRANS_A
+// RUN: torch-import %S/Inputs/linear.py --trans_b | FileCheck %s --check-prefix=TRANS_B
+
+// RUN: torch-import %S/Inputs/linear.py 2>/dev/null | \
+// RUN:   tpp-opt -default-tpp-passes | FileCheck %s --check-prefix=XSMM
+// RUN: torch-import %S/Inputs/linear.py 2>/dev/null | \
+// RUN:   tpp-opt -default-tpp-passes="nano-kernel" | FileCheck %s --check-prefix=NANO
+
+// REQUIRES: lighthouse
+
+// SINGLE_GEMM-LABEL: func.func @main(
+// SINGLE_GEMM: linalg.matmul
+
+// DOUBLE_GEMM-LABEL: func.func @main(
+// DOUBLE_GEMM-COUNT-2: linalg.matmul
+
+// MLP-LABEL: func.func @main(
+// MLP: linalg.matmul
+// MLP: linalg.generic
+// MLP: arith.addf
+// MLP: linalg.generic
+// MLP: arith.cmpf
+// MLP: arith.select
+
+// TRANS_A-LABEL: func.func @main(
+// TRANS_A: linalg.transpose ins(%arg0
+// TRANS_A: linalg.matmul
+
+// TRANS_B-LABEL: func.func @main(
+// TRANS_B: linalg.transpose ins(%cst_0
+// TRANS_B: linalg.matmul
+
+// XSMM-LABEL: func.func @main(
+// XSMM-SAME:    %[[ARG0:.+]]: memref<64x64xf32>) -> memref<64x64xf32>
+// XSMM-DAG:     memref.get_global @__constant_64x64xf32
+// XSMM:         call @xsmm_brgemm_dispatch
+// XSMM:         call @xsmm_brgemm_invoke
+// XSMM:         return
+
+// NANO-LABEL: func.func @main(
+// NANO-SAME:    %[[ARG0:.+]]: memref<64x64xf32>) -> memref<64x64xf32>
+// NANO:       scf.parallel
+// NANO:       vector.transfer_read
+// NANO:       vector.transfer_read
+// NANO:       vector.contract
+// NANO:       vector.transfer_write

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -66,3 +66,20 @@ for arch in config.targets_to_build.split():
     config.available_features.add(arch.lower() + "-registered-target")
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)
+
+# Lighthouse ingress: run the PyTorch import script inside the Lighthouse `uv`
+# environment. Only available when the submodule and `uv` are present, gated via
+# the 'lighthouse' feature (use with 'REQUIRES: lighthouse').
+import shutil
+
+lighthouse_dir = os.path.join(config.tpp_src_root, "third_party", "lighthouse")
+uv_path = shutil.which("uv")
+if uv_path and os.path.exists(os.path.join(lighthouse_dir, "pyproject.toml")):
+    config.available_features.add("lighthouse")
+    import_script = os.path.join(config.tpp_src_root, "tools", "pytorch", "import.py")
+    config.substitutions.append(
+        (
+            "torch-import",
+            f"{uv_path} run --project {lighthouse_dir} --extra ingress_torch_cpu {import_script}",
+        )
+    )

--- a/tools/pytorch/import.py
+++ b/tools/pytorch/import.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Convert a PyTorch model Python file into MLIR using the Lighthouse ingress.
+
+The input file must define a PyTorch ``nn.Module`` (class name ``Model`` by
+default) and a function returning sample inputs (``get_inputs`` by default).
+The resulting MLIR module is written to standard output, or to a file when the
+``-o/--output`` option is given.
+
+Run it inside the Lighthouse ``uv`` environment, e.g. from the tpp-mlir root:
+
+    uv run --project third_party/lighthouse tools/pytorch/import.py model.py
+"""
+
+import argparse
+import inspect
+import sys
+from pathlib import Path
+
+import torch
+
+from lighthouse.ingress.torch import import_from_model, import_model
+from lighthouse.utils.importer import import_python_module
+
+DIALECTS = ["linalg-on-tensors", "torch", "tosa", "stablehlo"]
+
+
+def eval_arg(expr):
+    """Evaluate a CLI value expression, falling back to the raw string."""
+    try:
+        return eval(expr, {"torch": torch})
+    except (NameError, SyntaxError):
+        return expr
+
+
+def parse_named_args(extras):
+    """Turn leftover '--name value' / '--name=value' / '--flag' args into a dict.
+
+    Names have dashes normalized to underscores. Values are evaluated with
+    'torch' in scope; bare flags become True.
+    """
+    named = {}
+    i = 0
+    while i < len(extras):
+        tok = extras[i]
+        if not tok.startswith("--"):
+            raise SystemExit(f"import.py: unexpected argument: {tok}")
+        key = tok[2:]
+        if "=" in key:
+            key, value = key.split("=", 1)
+            named[key.replace("-", "_")] = eval_arg(value)
+            i += 1
+        elif i + 1 < len(extras) and not extras[i + 1].startswith("--"):
+            named[key.replace("-", "_")] = eval_arg(extras[i + 1])
+            i += 2
+        else:
+            named[key.replace("-", "_")] = True
+            i += 1
+    return named
+
+
+def apply_init_overrides(model_file, model_class, base_args, overrides):
+    """Merge named overrides into the model constructor's positional init args.
+
+    'base_args' is the default positional init list (e.g. from get_init_inputs);
+    'overrides' maps constructor parameter names to values. Returns a positional
+    list with the overridden values placed at their parameter positions.
+    """
+    cls = getattr(import_python_module(Path(model_file)), model_class, None)
+    if cls is None:
+        raise SystemExit(f"import.py: model class '{model_class}' not found")
+
+    params = list(inspect.signature(cls.__init__).parameters.values())[1:]  # drop self
+    names = [p.name for p in params]
+    index = {name: i for i, name in enumerate(names)}
+
+    merged = list(base_args)
+    for name, value in overrides.items():
+        if name not in index:
+            raise SystemExit(
+                f"import.py: '--{name}' is not a constructor argument of {model_class}"
+            )
+        pos = index[name]
+        while len(merged) <= pos:
+            default = params[len(merged)].default
+            merged.append(None if default is inspect.Parameter.empty else default)
+        merged[pos] = value
+    return merged
+
+
+def make_splat_hooks():
+    """FX importer hook that emits uniform tensors as compact splat attributes.
+
+    torch-mlir materializes every multi-element constant as a dense_resource
+    blob, which bloats the output for large weights. When every element of a
+    tensor is identical, this hook emits a splat ``dense<value>`` instead.
+    """
+    from torch_mlir import ir
+    from torch_mlir.extras.fx_importer import FxImporterHooks, create_mlir_tensor_type
+
+    class SplatHooks(FxImporterHooks):
+        def resolve_literal(self, gni, literal, info):
+            if not isinstance(literal, torch.Tensor) or literal.numel() <= 1:
+                return None
+            flat = literal.reshape(-1)
+            if not bool(torch.all(flat == flat[0])):
+                return None
+
+            tensor_type = create_mlir_tensor_type(literal)
+            element_type = tensor_type.element_type
+            value = flat[0].item()
+            if literal.is_floating_point():
+                scalar = ir.FloatAttr.get(element_type, float(value))
+            else:
+                scalar = ir.IntegerAttr.get(element_type, int(value))
+
+            elements = ir.DenseElementsAttr.get_splat(tensor_type, scalar)
+            vtensor_type = gni._cc.tensor_to_vtensor_type(literal)
+            return ir.Operation.create(
+                name="torch.vtensor.literal",
+                results=[vtensor_type],
+                attributes={"value": elements},
+            ).result
+
+    return SplatHooks()
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "model_file",
+        help="Path to the Python file defining the PyTorch model.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        metavar="FILE",
+        help="Write MLIR to FILE instead of standard output.",
+    )
+    parser.add_argument(
+        "--model-class",
+        default="Model",
+        help="Name of the nn.Module class in the file (default: Model).",
+    )
+    parser.add_argument(
+        "--dialect",
+        choices=DIALECTS,
+        default="linalg-on-tensors",
+        help="Target MLIR dialect (default: linalg-on-tensors).",
+    )
+    parser.add_argument(
+        "--init-args-fn",
+        default="get_init_inputs",
+        help="Function returning the model init args, or 'none' to skip "
+        "(default: get_init_inputs).",
+    )
+    parser.add_argument(
+        "--init-args",
+        metavar="EXPR",
+        help="Python expression evaluated to the model init args (an iterable), "
+        "used instead of --init-args-fn. 'torch' is available. Example: '[64, 64]'.",
+    )
+    parser.add_argument(
+        "--sample-args-fn",
+        default="get_inputs",
+        help="Function returning the sample inputs (default: get_inputs).",
+    )
+    parser.add_argument(
+        "--sample-args",
+        metavar="EXPR",
+        help="Python expression evaluated to the sample inputs (an iterable), "
+        "used instead of --sample-args-fn. 'torch' is available. "
+        "Example: '(torch.ones(64, 64),)'.",
+    )
+    parser.add_argument(
+        "--splat",
+        action="store_true",
+        help="Emit uniform weight tensors as compact splat 'dense<value>' "
+        "attributes instead of full dense_resource blobs.",
+    )
+    # Unrecognized '--name value' args override the Model constructor by name.
+    return parser.parse_known_args(argv)
+
+
+def main(argv=None):
+    args, extras = parse_args(argv)
+
+    init_args_fn = None if args.init_args_fn.lower() == "none" else args.init_args_fn
+
+    model_init_args = None
+    if args.init_args is not None:
+        model_init_args = eval(args.init_args, {"torch": torch})
+
+    overrides = parse_named_args(extras)
+    if overrides:
+        base = model_init_args
+        if base is None and init_args_fn is not None:
+            module = import_python_module(Path(args.model_file))
+            init_fn = getattr(module, init_args_fn, None)
+            base = list(init_fn()) if init_fn is not None else []
+        model_init_args = apply_init_overrides(
+            args.model_file, args.model_class, base or [], overrides
+        )
+
+    sample_args = None
+    if args.sample_args is not None:
+        sample_args = eval(args.sample_args, {"torch": torch})
+
+    extra = {"hooks": make_splat_hooks()} if args.splat else {}
+
+    nn_model, sample_args, sample_kwargs = import_model(
+        args.model_file,
+        model_class_name=args.model_class,
+        init_args_fn_name=init_args_fn,
+        model_init_args=model_init_args,
+        sample_args_fn_name=args.sample_args_fn,
+        sample_args=sample_args,
+    )
+
+    mlir = import_from_model(
+        nn_model,
+        sample_args,
+        sample_kwargs=sample_kwargs,
+        dialect=args.dialect,
+        **extra,
+    )
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(str(mlir))
+            f.write("\n")
+    else:
+        print(mlir)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR adds a simple MLP inserter for PyTorch models. This replicates most of `mlir-gen` functionality while guaranteeing the output is exactly what torch import would do.

Caveats & TODOs:
* This is import mode rather than compile mode, so the values return from an empty. Need to add support for compile mode.
* Only tested on F32 type. Need to add support for other types.
* Transpose isn't well tested, probably lots of bugs. Need to harden it.
* No quantization support. This is for the future.