### PR TITLE
[NFC] Update benchmark script with scale type flag.

### DIFF
--- a/scripts/benchmarks/gen-sweep-config.py
+++ b/scripts/benchmarks/gen-sweep-config.py
@@ -45,7 +45,8 @@ DTYPES = {
             "--layers={K},{N} --tiles=32,32,32 --vnni=2"
         ),
         "run_args": (
-            "--def-parallel --bench-replication-gb=5 "
+            "--def-parallel --nano-kernels --gemm-unroll=16,16,16 "
+            "--registerBlocking=32,32,32 --bench-replication-gb=5 "
             "--init-type=normal --splat-to-random --seed=123"
         ),
         "extensions": ["amx_bf16"],

--- a/scripts/benchmarks/gen-sweep-config.py
+++ b/scripts/benchmarks/gen-sweep-config.py
@@ -28,7 +28,7 @@ DTYPES = {
         "gen_flags": (
             "--kernel=args --data-type=i8 --batch={M} "
             "--layers={K},{N} --tiles=32,32,64 --vnni=4 "
-            "--quant"
+            "--quant --scale-type=f8E8M0FNU"
         ),
         "run_args": (
             "--def-parallel --nano-kernels --gemm-unroll=16,16,16 "

--- a/scripts/benchmarks/run-sweep.sh
+++ b/scripts/benchmarks/run-sweep.sh
@@ -184,7 +184,7 @@ if [[ "${SKIP_CORRECTNESS}" -eq 0 ]]; then
   # mlir-gen flag templates (must match gen-sweep-config.py).
   # Use --kernel=args (same as the perf config); tpp-run --splat-to-random
   # --seed=123 makes both baseline and test runs see identical inputs.
-  gen_args_i8="--kernel=args --data-type=i8 --tiles=32,32,64 --vnni=4 --quant"
+  gen_args_i8="--kernel=args --data-type=i8 --tiles=32,32,64 --vnni=4 --quant --scale-type=f8E8M0FNU"
   gen_args_bf16="--kernel=args --data-type=bf16 --tiles=32,32,32 --vnni=2"
   # Data-init flags must be applied identically to baseline and test so both
   # runs see the same inputs; i8 requires --init-type=quant.


### PR DESCRIPTION
By default, scale argument type is set as f32. This change uses the flag '--scale-type' to set scale type explicitly as 'f8E8M0FNU' for the benchmark command for i8 quant kernel.