### PR TITLE
Add nano-gemm K-cache-blocking pass.

### DIFF
--- a/include/TPP/PassBundles.td
+++ b/include/TPP/PassBundles.td
@@ -56,6 +56,9 @@ def DefaultTppPasses : Pass<"default-tpp-passes", "ModuleOp"> {
            "unsigned", "Register blocking tile sizes for brgemm operation.">,
     ListOption<"gemmUnroll", "gemm-unroll", "int64_t",
                "GEMM unroll sizes for the innermost dims: [M, N, K]">,
+    Option<"kCacheBlocking", "k-cache-blocking", "unsigned", /*default=*/"0",
+           "Cache-block the GEMM reduction (K) dimension by this many "
+           "batch-reduce K-blocks. 0 disables.">,
 
   ];
 }
@@ -80,6 +83,10 @@ def TppMapping : Pass<"tpp-mapping", "ModuleOp"> {
     Option<"disableTileElementwiseOps", "disable-tile-elementwise-ops",
            "bool", /*default=*/"false",
            "Disables tiling of elementwise operations.">,
+    Option<"kCacheBlocking", "k-cache-blocking", "unsigned", /*default=*/"0",
+           "Cache-block the GEMM reduction (K) dimension by this many "
+           "batch-reduce K-blocks so the K-block loop encloses the spatial "
+           "tiling. 0 disables.">,
   ];
 }
 

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -130,6 +130,28 @@ def RegisterTiling : Pass<"tile-gemm"> {
   ];
 }
 
+def NanoGemmKCacheBlocking : Pass<"nano-gemm-k-cache-blocking"> {
+  let summary = "Cache-block the K dimension of a nano-kernel (AMX) GEMM.";
+  let description = [{
+    Runs after VectorContractToNanoKernels on the already-lowered AMX/memref
+    IR. Splits the batch-reduce (K) reduction loop of each nano GEMM tile by a
+    cache-block factor and hoists the resulting outer K-block loop OUTSIDE the
+    spatial scf.forall, so a K-block panel stays L2-resident across the tile
+    sweep. The bf16 output tile C is used as the cross-block accumulator
+    (beta=1): the first K-block seeds a zero bias, later blocks add the running
+    C tile (extf) into the f32 partial before rounding back to C. A value of 0
+    disables the pass, and the tile must evenly divide the batch-reduce extent.
+  }];
+  let dependentDialects = ["scf::SCFDialect",
+                           "memref::MemRefDialect",
+                           "vector::VectorDialect",
+                           "arith::ArithDialect"];
+  let options = [
+         Option<"kCacheTile", "k-cache-tile", "unsigned", /*default=*/"0",
+                "Batch-reduce (K-block) iterations per cache block. 0 disables.">,
+  ];
+}
+
 def ConvertLinalgGenericTo32BitAccumulation : Pass<"convert-linalg-generic-to-32-bit-acc"> {
    let summary = "Convert linalg.generic op from bf16/i8 to f32/i32 accumulation.";
    let description = [{

--- a/lib/TPP/DefaultPipeline.cpp
+++ b/lib/TPP/DefaultPipeline.cpp
@@ -101,6 +101,13 @@ llvm::cl::list<int64_t> gemmUnroll(
                    "vector.contract to register-sized shapes"),
     llvm::cl::CommaSeparated);
 
+llvm::cl::opt<unsigned> kCacheBlocking(
+    "k-cache-blocking",
+    llvm::cl::desc("Cache-block the GEMM reduction (K) dimension by this many "
+                   "batch-reduce K-blocks so the reused panel stays "
+                   "L2-resident. 0 disables."),
+    llvm::cl::init(0));
+
 namespace mlir {
 namespace tpp {
 #define GEN_PASS_DEF_DEFAULTPIPELINE
@@ -200,6 +207,7 @@ private:
         registerBlocking.begin(), registerBlocking.end()};
     tppDefaultOptions.gemmUnroll =
         SmallVector<int64_t>{gemmUnroll.begin(), gemmUnroll.end()};
+    tppDefaultOptions.kCacheBlocking = kCacheBlocking;
     tppDefaultOptions.nanoKernel = nanoKernel;
     tppDefaultOptions.defBundleCpuTargetFeature = pipelineCpuTargetFeature;
     pm.addPass(createDefaultTppPasses(tppDefaultOptions));

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -108,6 +108,14 @@ private:
     // No-op unless the benchmark producer requested replication.
     pm.addPass(createReplicateBenchArgs());
     pm.addNestedPass<func::FuncOp>(createVectorContractToNanoKernels());
+    // Cache-block the K dimension on the lowered AMX nano-kernel: hoist a
+    // K-block loop outside the spatial forall and accumulate into the bf16 C
+    // tile in place (beta=1). No-op when k-cache-blocking is 0.
+    if (kCacheBlocking > 0) {
+      NanoGemmKCacheBlockingOptions kCacheOpts;
+      kCacheOpts.kCacheTile = kCacheBlocking;
+      pm.addNestedPass<func::FuncOp>(createNanoGemmKCacheBlocking(kCacheOpts));
+    }
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     pm.addNestedPass<func::FuncOp>(createFlattenVectorOps());
     // Stream write-only stores (e.g. the output C matrix) with a nontemporal
@@ -126,6 +134,8 @@ private:
     // Applies a set of passes at the linalg level to fuse and pack.
     TppMappingOptions tppMappingOptions{lowerPackUnpackWithoutTranspose,
                                         disableVnniPacking};
+    // K-cache-blocking option initialization.
+    tppMappingOptions.kCacheBlocking = kCacheBlocking;
     pm.addPass(createTppMapping(tppMappingOptions));
     // Generalize linalg.pack and linalg.unpack.
     pm.addPass(createLowerPacksAndUnPacks());

--- a/lib/TPP/Transforms/CMakeLists.txt
+++ b/lib/TPP/Transforms/CMakeLists.txt
@@ -25,6 +25,7 @@ add_mlir_library(TPPTransforms
   FoldAddIntoDest.cpp
   Vectorization.cpp
   RegisterTiling.cpp
+  NanoGemmKCacheBlocking.cpp
   SplitReductionDim.cpp
   VectorContractToOuterproduct.cpp
   HoistVectorTransfers.cpp

--- a/lib/TPP/Transforms/NanoGemmKCacheBlocking.cpp
+++ b/lib/TPP/Transforms/NanoGemmKCacheBlocking.cpp
@@ -1,0 +1,294 @@
+//===- NanoGemmKCacheBlocking.cpp --------------------------------*-C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Cache-block the reduction (K) dimension of a nano-kernel (AMX) GEMM AFTER the
+// vector.contract has already been lowered to x86.amx.* ops. The batch-reduce
+// reduction loop that carries the AMX accumulator tiles is split by a
+// cache-block factor and the resulting outer K-block loop is hoisted OUTSIDE
+// the spatial scf.forall, so the A/B panel of a K-block stays L2-resident while
+// the whole tile grid is swept. The output tile C becomes the cross-block
+// accumulator (beta=1): the first K-block seeds a zero bias, every later block
+// adds the running accumulator into the partial before writing C back. For the
+// bf16 path C itself carries the running sum (extf to f32); for the quantized
+// i8->i8 path C cannot hold the wide partial and requant is non-linear, so a
+// dedicated full-grid i32 carrier threads the running sum across K-blocks and
+// the last block requantizes the full reduction. The non-quant i8->i32 path
+// already accumulates into its i32 C, so only the reduction is narrowed.
+//
+//===----------------------------------------------------------------------===//
+#include "TPP/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/APFloat.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "nano-gemm-k-cache-blocking"
+
+namespace mlir {
+namespace tpp {
+#define GEN_PASS_DEF_NANOGEMMKCACHEBLOCKING
+#include "TPP/Passes.h.inc"
+} // namespace tpp
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::tpp;
+
+namespace {
+
+// True when `op` is an x86 AMX op with the given mnemonic (checked by name so
+// the pass does not need to depend on the vendored X86 dialect headers).
+static bool isAmxOp(Operation *op, StringRef mnemonic) {
+  return op->getName().getStringRef() == mnemonic;
+}
+
+// The nano GEMM tile lowered inside a single scf.forall iteration. For the
+// float (bf16) path all fields must be found; the integer (i8->i32) path only
+// needs the reduction loop because its epilogue already accumulates into C.
+struct NanoGemmTile {
+  scf::ForOp brFor;         // batch-reduce reduction loop (carries AMX tiles)
+  scf::ForOp biasFor;       // per-row loop adding the bias into the f32 partial
+  memref::SubViewOp cTile;  // the 32x32 bf16 output tile subview
+  Value partialBuf;         // f32 scratch the AMX tiles are stored into
+  SmallVector<vector::LoadOp> biasLoads; // loads of the (zero) bias to rewrite
+  int64_t brExtent = 0;     // number of batch-reduce blocks (brFor upper bound)
+  bool isInteger = false;   // true for the i8 (tile_muli) path
+  bool isQuant = false;     // true for the quantized i8->i8 requant path
+};
+
+// Locate the blockable nano GEMM tile inside `forall`, or return failure.
+static FailureOr<NanoGemmTile> matchNanoGemmTile(scf::ForallOp forall) {
+  NanoGemmTile tile;
+
+  // The reduction loop is the scf.for whose body issues tile_mulf (bf16) or
+  // tile_muli (i8->i32).
+  forall.walk([&](scf::ForOp f) {
+    if (tile.brFor)
+      return;
+    for (Operation &op : f.getBody()->without_terminator()) {
+      if (isAmxOp(&op, "x86.amx.tile_mulf")) {
+        tile.brFor = f;
+        tile.isInteger = false;
+        return;
+      }
+      if (isAmxOp(&op, "x86.amx.tile_muli")) {
+        tile.brFor = f;
+        tile.isInteger = true;
+        return;
+      }
+    }
+  });
+  if (!tile.brFor)
+    return failure();
+
+  // A constant, zero-based, unit-step reduction loop is required so the split
+  // into an outer K-block loop is exact.
+  auto lb = getConstantIntValue(tile.brFor.getLowerBound());
+  auto ub = getConstantIntValue(tile.brFor.getUpperBound());
+  auto step = getConstantIntValue(tile.brFor.getStep());
+  if (!lb || !ub || !step || *lb != 0 || *step != 1)
+    return failure();
+  tile.brExtent = *ub;
+
+  // Distinguish the two integer pathss normal or quant.
+  if (tile.isInteger) {
+    bool hasRequant = false;
+    forall.walk([&](arith::FPToSIOp) { hasRequant = true; });
+    if (!hasRequant)
+      return tile;
+    tile.isQuant = true;
+  }
+
+  // The AMX tiles are stored into a scratch buffer (tile_store operand 0): f32
+  // for bf16, i32 for quantized i8.
+  forall.walk([&](Operation *op) {
+    if (isAmxOp(op, "x86.amx.tile_store"))
+      tile.partialBuf = op->getOperand(0);
+  });
+  if (!tile.partialBuf)
+    return failure();
+
+  // The bias-add loop reads the partial buffer plus a bias buffer, adds them
+  // and writes the sum back to the partial buffer. The bias loads are the
+  // ones re-sourced from the accumulator for beta=1.
+  forall.walk([&](scf::ForOp f) {
+    if (f == tile.brFor)
+      return;
+    bool loadsPartial = false;
+    SmallVector<vector::LoadOp> others;
+    for (auto ld : f.getBody()->getOps<vector::LoadOp>()) {
+      if (ld.getBase() == tile.partialBuf)
+        loadsPartial = true;
+      else
+        others.push_back(ld);
+    }
+    bool hasAdd = tile.isQuant
+                      ? !f.getBody()->getOps<arith::AddIOp>().empty()
+                      : !f.getBody()->getOps<arith::AddFOp>().empty();
+    if (loadsPartial && hasAdd && !others.empty()) {
+      tile.biasFor = f;
+      tile.biasLoads = others;
+    }
+  });
+  if (!tile.biasFor)
+    return failure();
+
+  // The output tile is the 2-D subview at the top level of the forall body
+  // bf16 for the float path, i8 for the quantized path.
+  for (auto sv : forall.getBody()->getOps<memref::SubViewOp>()) {
+    auto ty = dyn_cast<MemRefType>(sv.getType());
+    if (!ty || ty.getRank() != 2)
+      continue;
+    if (tile.isQuant ? ty.getElementType().isInteger(8)
+                     : ty.getElementType().isBF16())
+      tile.cTile = sv;
+  }
+  if (!tile.cTile)
+    return failure();
+
+  return tile;
+}
+
+// Rewrite one nano GEMM tile into a K-cache-blocked form.
+static void blockNanoGemmTile(scf::ForallOp forall, NanoGemmTile &tile,
+                              unsigned kCacheTile) {
+  Location loc = forall.getLoc();
+  OpBuilder b(forall);
+
+  Value c0 = arith::ConstantIndexOp::create(b, loc, 0);
+  Value cUB = arith::ConstantIndexOp::create(b, loc, tile.brExtent);
+  Value cKB = arith::ConstantIndexOp::create(b, loc, kCacheTile);
+
+  // The quantized path needs a full-grid i32 carrier that survives across
+  // K-blocks.
+  Value accBuf;
+  if (tile.isQuant) {
+    auto srcTy = cast<MemRefType>(tile.cTile.getSource().getType());
+    auto accTy = MemRefType::get(srcTy.getShape(), b.getI32Type());
+    accBuf = memref::AllocOp::create(b, loc, accTy);
+  }
+
+  // Outer K-block loop that encloses the whole spatial tile sweep.
+  auto kLoop = scf::ForOp::create(b, loc, c0, cUB, cKB);
+  Value kb = kLoop.getInductionVar();
+  forall->moveBefore(kLoop.getBody()->getTerminator());
+
+  if (accBuf) {
+    OpBuilder db(kLoop);
+    db.setInsertionPointAfter(kLoop);
+    memref::DeallocOp::create(db, loc, accBuf);
+  }
+
+  // Restrict the reduction loop to the current K-block: [kb, kb + kCacheTile).
+  {
+    OpBuilder rb(tile.brFor);
+    Value kbEnd = arith::AddIOp::create(rb, loc, kb, cKB);
+    tile.brFor.getLowerBoundMutable().assign(kb);
+    tile.brFor.getUpperBoundMutable().assign(kbEnd);
+  }
+
+  // The non-quant i8->i32 epilogue already accumulates into the i32 output C,
+  // hoisting the K-loop and narrowing the reduction is sufficient.
+  if (tile.isInteger && !tile.isQuant)
+    return;
+
+  OpBuilder eb(tile.biasFor);
+  Value isFirst =
+      arith::CmpIOp::create(eb, loc, arith::CmpIPredicate::eq, kb, c0);
+
+  if (tile.isQuant) {
+    // beta=1 against the dedicated i32 carrier: seed zero on the first K-block,
+    // otherwise re-load the running accumulator, and mirror the summed partial
+    // back into the carrier. The requant epilogue reads the running sum, so the
+    // last K-block requantizes the full K reduction.
+    auto cI8Ty = cast<MemRefType>(tile.cTile.getType());
+    auto accSvTy = MemRefType::get(cI8Ty.getShape(), eb.getI32Type(),
+                                   cI8Ty.getLayout(), cI8Ty.getMemorySpace());
+    auto accSv = memref::SubViewOp::create(
+        eb, loc, accSvTy, accBuf, tile.cTile.getMixedOffsets(),
+        tile.cTile.getMixedSizes(), tile.cTile.getMixedStrides());
+
+    for (vector::LoadOp bl : tile.biasLoads) {
+      OpBuilder lb(bl);
+      auto vecTy = cast<VectorType>(bl.getType());
+      Value accLoad = vector::LoadOp::create(lb, loc, vecTy, accSv.getResult(),
+                                             bl.getIndices());
+      Value zero = arith::ConstantOp::create(
+          lb, loc, vecTy, DenseElementsAttr::get(vecTy, APInt(32, 0)));
+      Value bias = arith::SelectOp::create(lb, loc, isFirst, zero, accLoad);
+      bl.getResult().replaceAllUsesWith(bias);
+      bl.erase();
+    }
+
+    SmallVector<vector::StoreOp> partialStores;
+    for (auto st : tile.biasFor.getBody()->getOps<vector::StoreOp>())
+      if (st.getBase() == tile.partialBuf)
+        partialStores.push_back(st);
+    for (vector::StoreOp st : partialStores) {
+      OpBuilder sb(st);
+      sb.setInsertionPointAfter(st);
+      vector::StoreOp::create(sb, loc, st.getValueToStore(), accSv.getResult(),
+                              st.getIndices());
+    }
+    return;
+  }
+
+  // bf16 beta=1: replace each zero-bias load with the running C tile (extf),
+  // except on the first K-block where the bias is zero.
+  Operation *cTileClone = eb.clone(*tile.cTile.getOperation());
+  Value cTileVal = cTileClone->getResult(0);
+
+  for (vector::LoadOp bl : tile.biasLoads) {
+    OpBuilder lb(bl);
+    auto f32VecTy = cast<VectorType>(bl.getType());
+    auto bf16VecTy = VectorType::get(f32VecTy.getShape(), lb.getBF16Type());
+    Value cLoad = vector::LoadOp::create(lb, loc, bf16VecTy, cTileVal,
+                                         bl.getIndices());
+    Value cExt = arith::ExtFOp::create(lb, loc, f32VecTy, cLoad);
+    Value zero = arith::ConstantOp::create(
+        lb, loc, f32VecTy,
+        DenseElementsAttr::get(f32VecTy, APFloat(0.0f)));
+    Value bias = arith::SelectOp::create(lb, loc, isFirst, zero, cExt);
+    bl.getResult().replaceAllUsesWith(bias);
+    bl.erase();
+  }
+}
+
+struct NanoGemmKCacheBlocking
+    : public tpp::impl::NanoGemmKCacheBlockingBase<NanoGemmKCacheBlocking> {
+  using NanoGemmKCacheBlockingBase::NanoGemmKCacheBlockingBase;
+
+  void runOnOperation() override {
+    if (kCacheTile == 0)
+      return;
+
+    SmallVector<std::pair<scf::ForallOp, NanoGemmTile>> targets;
+    getOperation()->walk([&](scf::ForallOp forall) {
+      auto tile = matchNanoGemmTile(forall);
+      if (failed(tile))
+        return;
+      // A block that spans (or exceeds) the whole K extent is a no-op; leave
+      // such tiles as the unblocked baseline. Only exact divisors are handled.
+      if (kCacheTile >= (unsigned)tile->brExtent ||
+          tile->brExtent % (int64_t)kCacheTile != 0)
+        return;
+      targets.emplace_back(forall, *tile);
+    });
+
+    for (auto &[forall, tile] : targets)
+      blockNanoGemmTile(forall, tile, kCacheTile);
+  }
+};
+
+} // namespace

--- a/test/Integration/BF16/AMX/nano-gemm-k-cache-blocking-correctness.mlir
+++ b/test/Integration/BF16/AMX/nano-gemm-k-cache-blocking-correctness.mlir
@@ -1,0 +1,34 @@
+// End-to-end correctness of nano (AMX) K-cache-blocking. The reduction (K) has
+// 8 batch-reduce blocks; blocking by 4 accumulates into a stationary bf16 C in
+// place.
+
+// RUN: tpp-run %s -e entry --entry-point-result=void -print --splat-to-random --init-type normal -seed 123 > %t.1
+// RUN: tpp-run %s -e entry --entry-point-result=void --nano-kernels --registerBlocking=32,32,32 --gemm-unroll=16,16,16 --k-cache-blocking=4 -print --splat-to-random --init-type normal -seed 123 > %t.2
+// RUN: fpcmp -r 0.01 %t.1 %t.2
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6, d3)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6, d5, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+module {
+  func.func @entry(%arg0: tensor<2x8x32x32xbf16>, %arg1: tensor<2x8x16x32x2xbf16>, %arg2: tensor<2x2x32x32xbf16>) -> tensor<2x2x32x32xbf16> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<2x2x32x32xf32>
+    %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<2x2x32x32xf32>) -> tensor<2x2x32x32xf32>
+    %expanded = tensor.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [2, 8, 32, 16, 2] : tensor<2x8x32x32xbf16> into tensor<2x8x32x16x2xbf16>
+    %2 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%expanded, %arg1 : tensor<2x8x32x16x2xbf16>, tensor<2x8x16x32x2xbf16>) outs(%1 : tensor<2x2x32x32xf32>) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: f32):
+      %4 = arith.extf %in : bf16 to f32
+      %5 = arith.extf %in_0 : bf16 to f32
+      %6 = arith.mulf %4, %5 : f32
+      %7 = arith.addf %out, %6 : f32
+      linalg.yield %7 : f32
+    } -> tensor<2x2x32x32xf32>
+    %3 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<2x2x32x32xf32>) outs(%arg2 : tensor<2x2x32x32xbf16>) {
+    ^bb0(%in: f32, %out: bf16):
+      %4 = arith.truncf %in : f32 to bf16
+      linalg.yield %4 : bf16
+    } -> tensor<2x2x32x32xbf16>
+    return %3 : tensor<2x2x32x32xbf16>
+  }
+}

--- a/test/Integration/I8/AMX/nano-gemm-k-cache-blocking-correctness.mlir
+++ b/test/Integration/I8/AMX/nano-gemm-k-cache-blocking-correctness.mlir
@@ -1,0 +1,46 @@
+// End-to-end correctness of quantized i8 nano (AMX) K-cache-blocking. The
+// reduction (K = 4*64 = 256) has 4 batch-reduce blocks; blocking by 2 threads
+// the wide i32 partial through a stationary i32 carrier (beta=1) and lets the
+// last K-block requantize the full reduction back to i8.
+
+// RUN: tpp-run %s -e entry --entry-point-result=void -print --splat-to-random --init-type quant -seed 123 > %t.1
+// RUN: tpp-run %s -e entry --entry-point-result=void --nano-kernels --registerBlocking=32,32,64 --gemm-unroll=16,16,16 --k-cache-blocking=2 -print --splat-to-random --init-type quant -seed 123 > %t.2
+// RUN: fpcmp -r 0.001 %t.1 %t.2
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6, d3)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6, d5, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, 0, d2, 0)>
+#map5 = affine_map<(d0, d1, d2, d3) -> (d1, 0, d3, 0)>
+module {
+  func.func @entry(%arg0: tensor<2x4x32x64xi8>, %arg1: tensor<64xf8E8M0FNU>, %arg2: tensor<2x4x16x32x4xi8>, %arg3: tensor<64xf8E8M0FNU>, %arg4: tensor<64xf8E8M0FNU>, %arg5: tensor<2x2x32x32xi8>) -> tensor<2x2x32x32xi8> {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tensor.empty() : tensor<2x2x32x32xi32>
+    %1 = linalg.fill ins(%c0_i32 : i32) outs(%0 : tensor<2x2x32x32xi32>) -> tensor<2x2x32x32xi32>
+    %expanded = tensor.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [2, 4, 32, 16, 4] : tensor<2x4x32x64xi8> into tensor<2x4x32x16x4xi8>
+    %2 = linalg.contract indexing_maps = [#map, #map1, #map2] ins(%expanded, %arg2 : tensor<2x4x32x16x4xi8>, tensor<2x4x16x32x4xi8>) outs(%1 : tensor<2x2x32x32xi32>) -> tensor<2x2x32x32xi32>
+    %expanded_0 = tensor.expand_shape %arg1 [[0, 1, 2, 3]] output_shape [2, 1, 32, 1] : tensor<64xf8E8M0FNU> into tensor<2x1x32x1xf8E8M0FNU>
+    %expanded_1 = tensor.expand_shape %arg3 [[0, 1, 2, 3]] output_shape [2, 1, 32, 1] : tensor<64xf8E8M0FNU> into tensor<2x1x32x1xf8E8M0FNU>
+    %expanded_2 = tensor.expand_shape %arg4 [[0, 1, 2, 3]] output_shape [2, 1, 32, 1] : tensor<64xf8E8M0FNU> into tensor<2x1x32x1xf8E8M0FNU>
+    %cst = arith.constant -1.280000e+02 : f32
+    %cst_3 = arith.constant 1.270000e+02 : f32
+    %3 = linalg.generic {indexing_maps = [#map3, #map4, #map5, #map5, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2, %expanded_0, %expanded_1, %expanded_2 : tensor<2x2x32x32xi32>, tensor<2x1x32x1xf8E8M0FNU>, tensor<2x1x32x1xf8E8M0FNU>, tensor<2x1x32x1xf8E8M0FNU>) outs(%arg5 : tensor<2x2x32x32xi8>) {
+    ^bb0(%in: i32, %in_4: f8E8M0FNU, %in_5: f8E8M0FNU, %in_6: f8E8M0FNU, %out: i8):
+      %4 = arith.sitofp %in : i32 to f32
+      %5 = arith.extf %in_4 : f8E8M0FNU to f32
+      %6 = arith.extf %in_5 : f8E8M0FNU to f32
+      %7 = arith.extf %in_6 : f8E8M0FNU to f32
+      %8 = arith.mulf %5, %6 : f32
+      %cst_7 = arith.constant 1.000000e+00 : f32
+      %9 = arith.divf %cst_7, %7 : f32
+      %10 = arith.mulf %8, %9 : f32
+      %11 = arith.mulf %4, %10 : f32
+      %12 = arith.maximumf %11, %cst : f32
+      %13 = arith.minimumf %12, %cst_3 : f32
+      %14 = arith.fptosi %13 : f32 to i8
+      linalg.yield %14 : i8
+    } -> tensor<2x2x32x32xi8>
+    return %3 : tensor<2x2x32x32xi8>
+  }
+}

--- a/test/Passes/AMX/nano-gemm-k-cache-blocking.mlir
+++ b/test/Passes/AMX/nano-gemm-k-cache-blocking.mlir
@@ -1,0 +1,248 @@
+// RUN: tpp-opt %s --nano-gemm-k-cache-blocking="k-cache-tile=2" --split-input-file | FileCheck %s
+// RUN: tpp-opt %s --nano-gemm-k-cache-blocking="k-cache-tile=0" --split-input-file | FileCheck -check-prefix=DISABLED %s
+
+// A lowered nano (AMX) GEMM tile: a batch-reduce reduction loop carrying an AMX
+// accumulator, stored to an f32 scratch, a bias-add loop, and a truncf store to
+// the bf16 output tile. K-cache-blocking by 2 (batch-reduce extent 4) must hoist
+// an outer K-block loop around the forall and accumulate into C in place.
+func.func @nano_gemm(%A: memref<4x16x32xbf16>, %B: memref<4x16x32xbf16>,
+                     %C: memref<2x2x16x16xbf16>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c16 = arith.constant 16 : index
+  %zero = memref.alloca() : memref<16x16xf32>
+  scf.forall (%t) in (4) {
+    %csub = memref.subview %C[0, 0, 0, 0] [1, 1, 16, 16] [1, 1, 1, 1]
+      : memref<2x2x16x16xbf16> to memref<16x16xbf16, strided<[16, 1]>>
+    %z = x86.amx.tile_zero : !x86.amx.tile<16x16xf32>
+    %r = scf.for %k = %c0 to %c4 step %c1 iter_args(%acc = %z)
+        -> (!x86.amx.tile<16x16xf32>) {
+      %la = x86.amx.tile_load %A[%k, %c0, %c0]
+        : memref<4x16x32xbf16> into !x86.amx.tile<16x32xbf16>
+      %lb = x86.amx.tile_load %B[%k, %c0, %c0]
+        : memref<4x16x32xbf16> into !x86.amx.tile<16x32xbf16>
+      %m = x86.amx.tile_mulf %la, %lb, %acc
+        : !x86.amx.tile<16x32xbf16>, !x86.amx.tile<16x32xbf16>, !x86.amx.tile<16x16xf32>
+      scf.yield %m : !x86.amx.tile<16x16xf32>
+    }
+    %part = memref.alloca() : memref<16x16xf32>
+    x86.amx.tile_store %part[%c0, %c0], %r
+      : memref<16x16xf32>, !x86.amx.tile<16x16xf32>
+    scf.for %row = %c0 to %c16 step %c1 {
+      %p = vector.load %part[%row, %c0] : memref<16x16xf32>, vector<16xf32>
+      %b = vector.load %zero[%row, %c0] : memref<16x16xf32>, vector<16xf32>
+      %s = arith.addf %p, %b : vector<16xf32>
+      vector.store %s, %part[%row, %c0] : memref<16x16xf32>, vector<16xf32>
+    }
+    scf.for %row = %c0 to %c16 step %c1 {
+      %p = vector.load %part[%row, %c0] : memref<16x16xf32>, vector<16xf32>
+      %tr = arith.truncf %p : vector<16xf32> to vector<16xbf16>
+      vector.store %tr, %csub[%row, %c0]
+        : memref<16x16xbf16, strided<[16, 1]>>, vector<16xbf16>
+    }
+  }
+  return
+}
+
+// The reduction loop runs over the full extent [0, 4); an outer K-block loop
+// with step 2 wraps the forall, the reduction is restricted to the block, and
+// the (previously zero) bias is re-sourced from C via extf/select (beta=1).
+// CHECK-LABEL: func.func @nano_gemm
+// CHECK: scf.for %[[KB:.+]] = %{{.+}} to %{{.+}} step %{{.+}} {
+// CHECK:   scf.forall
+// CHECK:     %[[END:.+]] = arith.addi %[[KB]], %{{.+}}
+// CHECK:     scf.for %{{.+}} = %[[KB]] to %[[END]] step
+// CHECK:       x86.amx.tile_mulf
+// CHECK:     x86.amx.tile_store
+// CHECK:     %[[FIRST:.+]] = arith.cmpi eq, %[[KB]], %{{.+}}
+// CHECK:     scf.for
+// CHECK:       %[[CV:.+]] = vector.load %{{.+}} : memref<16x16xbf16, strided<[16, 1]>>, vector<16xbf16>
+// CHECK:       %[[EXT:.+]] = arith.extf %[[CV]]
+// CHECK:       arith.select %[[FIRST]], %{{.+}}, %[[EXT]]
+
+// A tile size of 0 disables the pass; no K-block loop or beta=1 rewrite.
+// DISABLED-LABEL: func.func @nano_gemm
+// DISABLED-NOT: arith.select
+// DISABLED-NOT: arith.cmpi
+
+// -----
+
+// The block factor must divide the batch-reduce extent; extent 3 is not
+// divisible by 2, so the tile is left unchanged (no beta=1 rewrite).
+func.func @nano_gemm_no_divide(%A: memref<3x16x32xbf16>, %B: memref<3x16x32xbf16>,
+                               %C: memref<2x2x16x16xbf16>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c3 = arith.constant 3 : index
+  %c16 = arith.constant 16 : index
+  %zero = memref.alloca() : memref<16x16xf32>
+  scf.forall (%t) in (4) {
+    %csub = memref.subview %C[0, 0, 0, 0] [1, 1, 16, 16] [1, 1, 1, 1]
+      : memref<2x2x16x16xbf16> to memref<16x16xbf16, strided<[16, 1]>>
+    %z = x86.amx.tile_zero : !x86.amx.tile<16x16xf32>
+    %r = scf.for %k = %c0 to %c3 step %c1 iter_args(%acc = %z)
+        -> (!x86.amx.tile<16x16xf32>) {
+      %la = x86.amx.tile_load %A[%k, %c0, %c0]
+        : memref<3x16x32xbf16> into !x86.amx.tile<16x32xbf16>
+      %lb = x86.amx.tile_load %B[%k, %c0, %c0]
+        : memref<3x16x32xbf16> into !x86.amx.tile<16x32xbf16>
+      %m = x86.amx.tile_mulf %la, %lb, %acc
+        : !x86.amx.tile<16x32xbf16>, !x86.amx.tile<16x32xbf16>, !x86.amx.tile<16x16xf32>
+      scf.yield %m : !x86.amx.tile<16x16xf32>
+    }
+    %part = memref.alloca() : memref<16x16xf32>
+    x86.amx.tile_store %part[%c0, %c0], %r
+      : memref<16x16xf32>, !x86.amx.tile<16x16xf32>
+    scf.for %row = %c0 to %c16 step %c1 {
+      %p = vector.load %part[%row, %c0] : memref<16x16xf32>, vector<16xf32>
+      %b = vector.load %zero[%row, %c0] : memref<16x16xf32>, vector<16xf32>
+      %s = arith.addf %p, %b : vector<16xf32>
+      vector.store %s, %part[%row, %c0] : memref<16x16xf32>, vector<16xf32>
+    }
+    scf.for %row = %c0 to %c16 step %c1 {
+      %p = vector.load %part[%row, %c0] : memref<16x16xf32>, vector<16xf32>
+      %tr = arith.truncf %p : vector<16xf32> to vector<16xbf16>
+      vector.store %tr, %csub[%row, %c0]
+        : memref<16x16xbf16, strided<[16, 1]>>, vector<16xbf16>
+    }
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @nano_gemm_no_divide
+// CHECK-NOT: arith.select
+// CHECK-NOT: arith.cmpi
+
+// -----
+
+// A lowered quantized nano (AMX) GEMM tile: an i8 batch-reduce reduction into a
+// wide i32 accumulator, an addi bias-add loop against a zero i32 bias, and a
+// requant loop (sitofp, clamp, fptosi) storing the i8 output tile. Because the
+// i8 C cannot carry the wide partial and requant is non-linear, K-cache-blocking
+// must thread the running sum through a dedicated i32 carrier (beta=1) and let
+// the last K-block requantize the full reduction.
+func.func @nano_gemm_quant(%A: memref<4x16x64xi8>, %B: memref<4x16x64xi8>,
+                           %C: memref<2x2x16x16xi8>,
+                           %iScale: memref<16xf32>, %wScale: memref<16xf32>,
+                           %oScale: memref<16xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c16 = arith.constant 16 : index
+  %lo = arith.constant dense<-1.280000e+02> : vector<16xf32>
+  %hi = arith.constant dense<1.270000e+02> : vector<16xf32>
+  %zero = memref.alloca() : memref<16x16xi32>
+  scf.forall (%t) in (4) {
+    %csub = memref.subview %C[0, 0, 0, 0] [1, 1, 16, 16] [1, 1, 1, 1]
+      : memref<2x2x16x16xi8> to memref<16x16xi8, strided<[16, 1]>>
+    %z = x86.amx.tile_zero : !x86.amx.tile<16x16xi32>
+    %r = scf.for %k = %c0 to %c4 step %c1 iter_args(%acc = %z)
+        -> (!x86.amx.tile<16x16xi32>) {
+      %la = x86.amx.tile_load %A[%k, %c0, %c0]
+        : memref<4x16x64xi8> into !x86.amx.tile<16x64xi8>
+      %lb = x86.amx.tile_load %B[%k, %c0, %c0]
+        : memref<4x16x64xi8> into !x86.amx.tile<16x64xi8>
+      %m = x86.amx.tile_muli %la, %lb, %acc
+        : !x86.amx.tile<16x64xi8>, !x86.amx.tile<16x64xi8>, !x86.amx.tile<16x16xi32>
+      scf.yield %m : !x86.amx.tile<16x16xi32>
+    }
+    %part = memref.alloca() : memref<16x16xi32>
+    x86.amx.tile_store %part[%c0, %c0], %r
+      : memref<16x16xi32>, !x86.amx.tile<16x16xi32>
+    scf.for %row = %c0 to %c16 step %c1 {
+      %p = vector.load %part[%row, %c0] : memref<16x16xi32>, vector<16xi32>
+      %b = vector.load %zero[%row, %c0] : memref<16x16xi32>, vector<16xi32>
+      %s = arith.addi %p, %b : vector<16xi32>
+      vector.store %s, %part[%row, %c0] : memref<16x16xi32>, vector<16xi32>
+    }
+    scf.for %row = %c0 to %c16 step %c1 {
+      %p = vector.load %part[%row, %c0] : memref<16x16xi32>, vector<16xi32>
+      %pf = arith.sitofp %p : vector<16xi32> to vector<16xf32>
+      %cl = arith.maximumf %pf, %lo : vector<16xf32>
+      %ch = arith.minimumf %cl, %hi : vector<16xf32>
+      %q = arith.fptosi %ch : vector<16xf32> to vector<16xi8>
+      vector.store %q, %csub[%row, %c0]
+        : memref<16x16xi8, strided<[16, 1]>>, vector<16xi8>
+    }
+  }
+  return
+}
+
+// A full-grid i32 carrier is allocated outside the hoisted K-block loop; the
+// reduction runs over the block, the (zero) bias is re-sourced from the carrier
+// via select (beta=1), and the summed partial is mirrored back into the carrier.
+// CHECK-LABEL: func.func @nano_gemm_quant
+// CHECK: %[[ACC:.+]] = memref.alloc() : memref<2x2x16x16xi32>
+// CHECK: scf.for %[[KB:.+]] = %{{.+}} to %{{.+}} step %{{.+}} {
+// CHECK:   scf.forall
+// CHECK:     %[[END:.+]] = arith.addi %[[KB]], %{{.+}}
+// CHECK:     scf.for %{{.+}} = %[[KB]] to %[[END]] step
+// CHECK:       x86.amx.tile_muli
+// CHECK:     x86.amx.tile_store
+// CHECK:     %[[FIRST:.+]] = arith.cmpi eq, %[[KB]], %{{.+}}
+// CHECK:     %[[ACCSV:.+]] = memref.subview %[[ACC]]
+// CHECK:     scf.for
+// CHECK:       %[[AV:.+]] = vector.load %[[ACCSV]]
+// CHECK:       arith.select %[[FIRST]], %{{.+}}, %[[AV]]
+// CHECK:       arith.addi
+// CHECK:       vector.store %{{.+}}, %[[ACCSV]]
+// CHECK: memref.dealloc %[[ACC]]
+
+// DISABLED-LABEL: func.func @nano_gemm_quant
+// DISABLED-NOT: memref.alloc()
+// DISABLED-NOT: arith.select
+
+// -----
+
+// The block factor must divide the batch-reduce extent; extent 3 is not
+// divisible by 2, so the quantized tile is left unchanged (no carrier/rewrite).
+func.func @nano_gemm_quant_no_divide(%A: memref<3x16x64xi8>, %B: memref<3x16x64xi8>,
+                                     %C: memref<2x2x16x16xi8>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c3 = arith.constant 3 : index
+  %c16 = arith.constant 16 : index
+  %lo = arith.constant dense<-1.280000e+02> : vector<16xf32>
+  %hi = arith.constant dense<1.270000e+02> : vector<16xf32>
+  %zero = memref.alloca() : memref<16x16xi32>
+  scf.forall (%t) in (4) {
+    %csub = memref.subview %C[0, 0, 0, 0] [1, 1, 16, 16] [1, 1, 1, 1]
+      : memref<2x2x16x16xi8> to memref<16x16xi8, strided<[16, 1]>>
+    %z = x86.amx.tile_zero : !x86.amx.tile<16x16xi32>
+    %r = scf.for %k = %c0 to %c3 step %c1 iter_args(%acc = %z)
+        -> (!x86.amx.tile<16x16xi32>) {
+      %la = x86.amx.tile_load %A[%k, %c0, %c0]
+        : memref<3x16x64xi8> into !x86.amx.tile<16x64xi8>
+      %lb = x86.amx.tile_load %B[%k, %c0, %c0]
+        : memref<3x16x64xi8> into !x86.amx.tile<16x64xi8>
+      %m = x86.amx.tile_muli %la, %lb, %acc
+        : !x86.amx.tile<16x64xi8>, !x86.amx.tile<16x64xi8>, !x86.amx.tile<16x16xi32>
+      scf.yield %m : !x86.amx.tile<16x16xi32>
+    }
+    %part = memref.alloca() : memref<16x16xi32>
+    x86.amx.tile_store %part[%c0, %c0], %r
+      : memref<16x16xi32>, !x86.amx.tile<16x16xi32>
+    scf.for %row = %c0 to %c16 step %c1 {
+      %p = vector.load %part[%row, %c0] : memref<16x16xi32>, vector<16xi32>
+      %b = vector.load %zero[%row, %c0] : memref<16x16xi32>, vector<16xi32>
+      %s = arith.addi %p, %b : vector<16xi32>
+      vector.store %s, %part[%row, %c0] : memref<16x16xi32>, vector<16xi32>
+    }
+    scf.for %row = %c0 to %c16 step %c1 {
+      %p = vector.load %part[%row, %c0] : memref<16x16xi32>, vector<16xi32>
+      %pf = arith.sitofp %p : vector<16xi32> to vector<16xf32>
+      %cl = arith.maximumf %pf, %lo : vector<16xf32>
+      %ch = arith.minimumf %cl, %hi : vector<16xf32>
+      %q = arith.fptosi %ch : vector<16xf32> to vector<16xi8>
+      vector.store %q, %csub[%row, %c0]
+        : memref<16x16xi8, strided<[16, 1]>>, vector<16xi8>
+    }
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @nano_gemm_quant_no_divide
+// CHECK-NOT: memref.alloc()
+// CHECK-NOT: arith.select
+// CHECK-NOT: arith.cmpi


### PR DESCRIPTION
Introduce a post-nano AMX K-cache-blocking transformation that hoists a K-block loop outside the parallel forall so the reused B panel stays L2-resident across the reduction:

- NanoGemmKCacheBlocking pass: bf16 path threads the C tile in place, i8 quant path threads the wide i32 accumulator and runs the requant epilogue once after the K-loop.
- Expose --k-cache-blocking through the tpp-run CLI, forwarded into the nano vectorization path. Opt-in (default 0) i.e. disabled by default.